### PR TITLE
build: as of Go 1.21, toolchain versions must use the 1.N.P syntax

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,13 @@
 version: 2
 updates:
+  - package-ecosystem: gomod
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      all-go:
+        patterns:
+          - "*"
   - package-ecosystem: github-actions
     directory: "/"
     schedule:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/BeyondTrust/go-client-library-passwordsafe
 
-go 1.21
+go 1.21.9
 
 require (
 	github.com/cenkalti/backoff/v4 v4.2.1 // indirect


### PR DESCRIPTION
Addresses CodeQL warning:
![image](https://github.com/BeyondTrust/go-client-library-passwordsafe/assets/89025319/7e0a24f1-3bc1-4507-9ee2-1c866bc51c5a)

> As of Go 1.21, toolchain versions [must use the 1.N.P syntax](https://go.dev/doc/toolchain#version).
>
> 1.21 in go.mod does not match this syntax and there is no additional toolchain directive, which may cause some go commands to fail.

Also added the `gomod` package ecosystem to the dependabot configuration file.