### PR TITLE
feat: add writing secrets feature in terraform provider

### DIFF
--- a/TestClient.go
+++ b/TestClient.go
@@ -10,6 +10,7 @@ import (
 	managed_accounts "github.com/BeyondTrust/go-client-library-passwordsafe/api/managed_account"
 	"github.com/BeyondTrust/go-client-library-passwordsafe/api/secrets"
 	"github.com/BeyondTrust/go-client-library-passwordsafe/api/utils"
+	"github.com/google/uuid"
 
 	//"os"
 
@@ -75,7 +76,7 @@ func main() {
 	authenticate, _ := authentication.Authenticate(*httpClientObj, backoffDefinition, apiUrl, clientId, clientSecret, zapLogger, retryMaxElapsedTimeMinutes)
 
 	// authenticating
-	_, err := authenticate.GetPasswordSafeAuthentication()
+	userObject, err := authenticate.GetPasswordSafeAuthentication()
 	if err != nil {
 		return
 	}
@@ -156,6 +157,107 @@ func main() {
 
 	// WARNING: Do not log secrets in production code, the following log statement logs test secrets for testing purposes:
 	zapLogger.Warn(fmt.Sprintf("Created Managed Account: %v", createResponse.AccountName))
+
+	objCredential := entities.SecretCredentialDetails{
+		Title:       "CREDENTIAL_" + uuid.New().String(),
+		Description: "My Credential Secret Description",
+		Username:    "my_user",
+		Password:    "MyPass2#$!",
+		OwnerType:   "User",
+		Notes:       "My note",
+		Owners: []entities.OwnerDetails{
+			{
+				OwnerId: userObject.UserId,
+				Owner:   userObject.UserName,
+				Email:   userObject.EmailAddress,
+			},
+		},
+		Urls: []entities.UrlDetails{
+			{
+				Id:           uuid.New(),
+				CredentialId: uuid.New(),
+				Url:          "https://www.test.com/",
+			},
+		},
+	}
+
+	// creating a credential secret in folder1.
+	createdSecret, err := secretObj.CreateSecretFlow("folder1", objCredential)
+
+	if err != nil {
+		zapLogger.Error(err.Error())
+		return
+	}
+	// WARNING: Do not log secrets in production code, the following log statement logs test secrets for testing purposes:
+	zapLogger.Debug(fmt.Sprintf("Created Credential secret: %v", createdSecret.Title))
+
+	objText := entities.SecretTextDetails{
+		Title:       "TEXT_" + uuid.New().String(),
+		Description: "My Text Secret Description",
+		Text:        "my_p4ssword!*2024",
+		OwnerType:   "User",
+		OwnerId:     userObject.UserId,
+		FolderId:    uuid.New(),
+		Owners: []entities.OwnerDetails{
+			{
+				OwnerId: userObject.UserId,
+				Owner:   userObject.UserName,
+				Email:   userObject.EmailAddress,
+			},
+		},
+		Urls: []entities.UrlDetails{
+			{
+				Id:           uuid.New(),
+				CredentialId: uuid.New(),
+				Url:          "https://www.test.com/",
+			},
+		},
+	}
+
+	// creating a text secret in folder1.
+	createdSecret, err = secretObj.CreateSecretFlow("folder1", objText)
+
+	if err != nil {
+		zapLogger.Error(err.Error())
+		return
+	}
+	// WARNING: Do not log secrets in production code, the following log statement logs test secrets for testing purposes:
+	zapLogger.Debug(fmt.Sprintf("Created Text secret: %v", createdSecret.Title))
+
+	objFile := entities.SecretFileDetails{
+		Title:       "FILE_" + uuid.New().String(),
+		Description: "My File Secret Description",
+		OwnerType:   "User",
+		OwnerId:     userObject.UserId,
+		Owners: []entities.OwnerDetails{
+			{
+				OwnerId: userObject.UserId,
+				Owner:   userObject.UserName,
+				Email:   userObject.EmailAddress,
+			},
+		},
+		Notes:       "Notes 1",
+		FileName:    "my_secret.txt",
+		FileContent: "my_p4ssword!*2024",
+		Urls: []entities.UrlDetails{
+			{
+				Id:           uuid.New(),
+				CredentialId: uuid.New(),
+				Url:          "https://www.test.com/",
+			},
+		},
+	}
+
+	// creating a file secret in folder1.
+	createdSecret, err = secretObj.CreateSecretFlow("folder1", objFile)
+
+	if err != nil {
+		zapLogger.Error(err.Error())
+		return
+	}
+
+	// WARNING: Do not log secrets in production code, the following log statement logs test secrets for testing purposes:
+	zapLogger.Debug(fmt.Sprintf("Created File secret: %v", createdSecret.Title))
 
 	// signing out
 	_ = authenticate.SignOut()

--- a/api/authentication/authentication.go
+++ b/api/authentication/authentication.go
@@ -99,7 +99,7 @@ func (authenticationObj *AuthenticationObj) GetToken(endpointUrl string, clientI
 	buffer.WriteString(params.Encode())
 
 	technicalError = backoff.Retry(func() error {
-		body, _, technicalError, businessError = authenticationObj.HttpClient.CallSecretSafeAPI(endpointUrl, "POST", buffer, "GetToken", "", "")
+		body, _, technicalError, businessError = authenticationObj.HttpClient.CallSecretSafeAPI(endpointUrl, "POST", buffer, "GetToken", "", "", "application/json")
 		return technicalError
 	}, authenticationObj.ExponentialBackOff)
 
@@ -144,7 +144,7 @@ func (authenticationObj *AuthenticationObj) SignAppin(endpointUrl string, access
 	var scode int
 
 	err := backoff.Retry(func() error {
-		body, scode, technicalError, businessError = authenticationObj.HttpClient.CallSecretSafeAPI(endpointUrl, "POST", bytes.Buffer{}, "SignAppin", accessToken, apiKey)
+		body, scode, technicalError, businessError = authenticationObj.HttpClient.CallSecretSafeAPI(endpointUrl, "POST", bytes.Buffer{}, "SignAppin", accessToken, apiKey, "application/json")
 		if scode == 0 {
 			return nil
 		}
@@ -189,7 +189,7 @@ func (authenticationObj *AuthenticationObj) SignOut() error {
 	var body io.ReadCloser
 
 	technicalError = backoff.Retry(func() error {
-		body, _, technicalError, businessError = authenticationObj.HttpClient.CallSecretSafeAPI(authenticationObj.ApiUrl.JoinPath("Auth/Signout").String(), "POST", bytes.Buffer{}, "SignOut", "", "")
+		body, _, technicalError, businessError = authenticationObj.HttpClient.CallSecretSafeAPI(authenticationObj.ApiUrl.JoinPath("Auth/Signout").String(), "POST", bytes.Buffer{}, "SignOut", "", "", "application/json")
 		return technicalError
 	}, authenticationObj.ExponentialBackOff)
 

--- a/api/entities/entities.go
+++ b/api/entities/entities.go
@@ -2,6 +2,10 @@
 // Package entities implements DTO's used by Beyondtrust Secret Safe API.
 package entities
 
+import (
+	"github.com/google/uuid"
+)
+
 // SignApinResponse responsbile for API sign in information.
 type SignApinResponse struct {
 	UserId       int    `json:"UserId"`
@@ -81,4 +85,66 @@ type AccountDetails struct {
 	ChangeDComFlag                    bool   `validate:"omitempty"`
 	ChangeSComFlag                    bool   `validate:"omitempty"`
 	ObjectID                          string `validate:"omitempty,max=36"`
+}
+
+type FolderResponse struct {
+	Id          string
+	Name        string
+	Description string
+}
+
+type CreateSecretResponse struct {
+	Id          string
+	Title       string
+	Description string
+	FolderId    string
+}
+
+type SecretCredentialDetails struct {
+	Title          string         `json:",omitempty" validate:"required"`
+	Description    string         `json:",omitempty" validate:"omitempty,max=256"`
+	Username       string         `json:",omitempty" validate:"required"`
+	Password       string         `json:",omitempty" validate:"max=256,required_without=PasswordRuleID"`
+	OwnerId        int            `json:",omitempty" validate:"required_if=OwnerType Group"`
+	OwnerType      string         `json:",omitempty" validate:"required,oneof=User Group"`
+	Owners         []OwnerDetails `json:",omitempty" validate:"required_if=OwnerType User"`
+	Notes          string         `json:",omitempty" validate:"omitempty,max=4000"`
+	Urls           []UrlDetails   `json:",omitempty" validate:"omitempty"`
+	PasswordRuleID int            `json:",omitempty" validate:"omitempty"`
+}
+
+type SecretTextDetails struct {
+	Title       string         `json:",omitempty" validate:"required,max=256"`
+	Description string         `json:",omitempty" validate:"omitempty,max=256"`
+	Text        string         `json:",omitempty" validate:"required,max=4096"`
+	OwnerId     int            `json:",omitempty" validate:"required_if=OwnerType Group"`
+	OwnerType   string         `json:",omitempty" validate:"required,oneof=User Group"`
+	Owners      []OwnerDetails `json:",omitempty" validate:"required_if=OwnerType User"`
+	Notes       string         `json:",omitempty" validate:"omitempty,max=4000"`
+	FolderId    uuid.UUID      `json:",omitempty" validate:"omitempty"`
+	Urls        []UrlDetails   `json:",omitempty" validate:"omitempty"`
+}
+
+type SecretFileDetails struct {
+	Title       string         `json:",omitempty" validate:"required,max=256"`
+	Description string         `json:",omitempty" validate:"omitempty,max=256"`
+	OwnerId     int            `json:",omitempty" validate:"required_if=OwnerType Group"`
+	OwnerType   string         `json:",omitempty" validate:"required,oneof=User Group"`
+	Owners      []OwnerDetails `json:",omitempty" validate:"required_if=OwnerType User"`
+	Notes       string         `json:",omitempty" validate:"omitempty,max=4000"`
+	FileName    string         `json:",omitempty" validate:"required,max=256"`
+	FileContent string         `json:",omitempty" validate:"required,max=256"`
+	Urls        []UrlDetails   `json:",omitempty" validate:"omitempty"`
+}
+
+type OwnerDetails struct {
+	OwnerId int    `json:",omitempty" validate:"required,min=1,max=2147483647"`
+	Owner   string `json:",omitempty" validate:"omitempty"`
+	Email   string `json:",omitempty" validate:"omitempty"`
+}
+
+type UrlDetails struct {
+	Id           uuid.UUID `json:",omitempty" validate:"omitempty,uuid"`
+	CredentialId uuid.UUID `json:",omitempty" validate:"omitempty,uuid"`
+	Url          string    `json:",omitempty" validate:"required,max=2048,url"`
 }

--- a/api/managed_account/managed_account.go
+++ b/api/managed_account/managed_account.go
@@ -116,7 +116,7 @@ func (managedAccountObj *ManagedAccountstObj) ManagedAccountGet(systemName strin
 	var businessError error
 
 	technicalError = backoff.Retry(func() error {
-		body, _, technicalError, businessError = managedAccountObj.authenticationObj.HttpClient.CallSecretSafeAPI(url, "GET", bytes.Buffer{}, "ManagedAccountGet", "", "")
+		body, _, technicalError, businessError = managedAccountObj.authenticationObj.HttpClient.CallSecretSafeAPI(url, "GET", bytes.Buffer{}, "ManagedAccountGet", "", "", "application/json")
 		if technicalError != nil {
 			return technicalError
 		}
@@ -163,7 +163,7 @@ func (managedAccountObj *ManagedAccountstObj) ManagedAccountCreateRequest(system
 	var businessError error
 
 	technicalError = backoff.Retry(func() error {
-		body, _, technicalError, businessError = managedAccountObj.authenticationObj.HttpClient.CallSecretSafeAPI(url, "POST", *b, "ManagedAccountCreateRequest", "", "")
+		body, _, technicalError, businessError = managedAccountObj.authenticationObj.HttpClient.CallSecretSafeAPI(url, "POST", *b, "ManagedAccountCreateRequest", "", "", "application/json")
 		return technicalError
 	}, managedAccountObj.authenticationObj.ExponentialBackOff)
 
@@ -199,7 +199,7 @@ func (managedAccountObj *ManagedAccountstObj) CredentialByRequestId(requestId st
 	var businessError error
 
 	technicalError = backoff.Retry(func() error {
-		body, _, technicalError, businessError = managedAccountObj.authenticationObj.HttpClient.CallSecretSafeAPI(url, "GET", bytes.Buffer{}, "CredentialByRequestId", "", "")
+		body, _, technicalError, businessError = managedAccountObj.authenticationObj.HttpClient.CallSecretSafeAPI(url, "GET", bytes.Buffer{}, "CredentialByRequestId", "", "", "application/json")
 		return technicalError
 	}, managedAccountObj.authenticationObj.ExponentialBackOff)
 
@@ -235,7 +235,7 @@ func (managedAccountObj *ManagedAccountstObj) ManagedAccountRequestCheckIn(reque
 	var businessError error
 
 	technicalError = backoff.Retry(func() error {
-		_, _, technicalError, businessError = managedAccountObj.authenticationObj.HttpClient.CallSecretSafeAPI(url, "PUT", *b, "ManagedAccountRequestCheckIn", "", "")
+		_, _, technicalError, businessError = managedAccountObj.authenticationObj.HttpClient.CallSecretSafeAPI(url, "PUT", *b, "ManagedAccountRequestCheckIn", "", "", "application/json")
 		return technicalError
 	}, managedAccountObj.authenticationObj.ExponentialBackOff)
 
@@ -310,7 +310,7 @@ func (managedAccountObj *ManagedAccountstObj) ManagedAccountCreateManagedAccount
 	var businessError error
 
 	technicalError = backoff.Retry(func() error {
-		body, _, technicalError, businessError = managedAccountObj.authenticationObj.HttpClient.CallSecretSafeAPI(url, "POST", *b, "ManagedAccountCreateManagedAccount", "", "")
+		body, _, technicalError, businessError = managedAccountObj.authenticationObj.HttpClient.CallSecretSafeAPI(url, "POST", *b, "ManagedAccountCreateManagedAccount", "", "", "application/json")
 		return technicalError
 	}, managedAccountObj.authenticationObj.ExponentialBackOff)
 
@@ -352,7 +352,7 @@ func (managedAccountObj *ManagedAccountstObj) ManagedSystemGetSystems(url string
 	var businessError error
 
 	technicalError = backoff.Retry(func() error {
-		body, _, technicalError, businessError = managedAccountObj.authenticationObj.HttpClient.CallSecretSafeAPI(url, "GET", bytes.Buffer{}, "ManagedSystemGetSystems", "", "")
+		body, _, technicalError, businessError = managedAccountObj.authenticationObj.HttpClient.CallSecretSafeAPI(url, "GET", bytes.Buffer{}, "ManagedSystemGetSystems", "", "", "application/json")
 		if technicalError != nil {
 			return technicalError
 		}

--- a/api/secrets/secrets.go
+++ b/api/secrets/secrets.go
@@ -242,8 +242,6 @@ func (secretObj *SecretObj) SecretCreateSecret(folderId string, secretDetails in
 
 	payload := string(secretCredentialDetailsJson)
 
-	secretObj.log.Debug(payload)
-
 	var CreateSecretResponse entities.CreateSecretResponse
 
 	b := bytes.NewBufferString(payload)
@@ -259,8 +257,8 @@ func (secretObj *SecretObj) SecretCreateSecret(folderId string, secretDetails in
 		path = "secrets/file"
 	}
 
-	SecretCreateSecreUrl := secretObj.authenticationObj.ApiUrl.JoinPath("secrets-safe/folders", folderId, path).String()
-	messageLog := fmt.Sprintf("%v %v", "POST", SecretCreateSecreUrl)
+	SecretCreateSecretUrl := secretObj.authenticationObj.ApiUrl.JoinPath("secrets-safe/folders", folderId, path).String()
+	messageLog := fmt.Sprintf("%v %v", "POST", SecretCreateSecretUrl)
 	secretObj.log.Debug(messageLog)
 
 	var fileSecret entities.SecretFileDetails
@@ -269,7 +267,7 @@ func (secretObj *SecretObj) SecretCreateSecret(folderId string, secretDetails in
 	// file secrets have a special behavior, they need to be created using multipart request.
 	if path == "secrets/file" {
 		if fileSecret, ok = secretDetails.(entities.SecretFileDetails); ok {
-			body, err := secretObj.authenticationObj.HttpClient.CreateMultiPartRequest(SecretCreateSecreUrl, fileSecret.FileName, []byte(payload), fileSecret.FileContent)
+			body, err := secretObj.authenticationObj.HttpClient.CreateMultiPartRequest(SecretCreateSecretUrl, fileSecret.FileName, []byte(payload), fileSecret.FileContent)
 			if err != nil {
 				return entities.CreateSecretResponse{}, err
 			}
@@ -295,7 +293,7 @@ func (secretObj *SecretObj) SecretCreateSecret(folderId string, secretDetails in
 	var businessError error
 
 	technicalError = backoff.Retry(func() error {
-		body, _, technicalError, businessError = secretObj.authenticationObj.HttpClient.CallSecretSafeAPI(SecretCreateSecreUrl, "POST", *b, "SecretCreateSecret", "", "", "application/json")
+		body, _, technicalError, businessError = secretObj.authenticationObj.HttpClient.CallSecretSafeAPI(SecretCreateSecretUrl, "POST", *b, "SecretCreateSecret", "", "", "application/json")
 		return technicalError
 	}, secretObj.authenticationObj.ExponentialBackOff)
 

--- a/api/secrets/secrets.go
+++ b/api/secrets/secrets.go
@@ -118,7 +118,7 @@ func (secretObj *SecretObj) SecretGetSecretByPath(secretPath string, secretTitle
 	secretObj.log.Debug(messageLog)
 
 	technicalError = backoff.Retry(func() error {
-		body, scode, technicalError, businessError = secretObj.authenticationObj.HttpClient.CallSecretSafeAPI(url, "GET", bytes.Buffer{}, "SecretGetSecretByPath", "", "")
+		body, scode, technicalError, businessError = secretObj.authenticationObj.HttpClient.CallSecretSafeAPI(url, "GET", bytes.Buffer{}, "SecretGetSecretByPath", "", "", "application/json")
 		return technicalError
 	}, secretObj.authenticationObj.ExponentialBackOff)
 
@@ -166,7 +166,7 @@ func (secretObj *SecretObj) SecretGetFileSecret(secretId string, endpointPath st
 	url := secretObj.authenticationObj.ApiUrl.JoinPath(endpointPath, secretId, "/file/download").String()
 
 	technicalError = backoff.Retry(func() error {
-		body, _, technicalError, businessError = secretObj.authenticationObj.HttpClient.CallSecretSafeAPI(url, "GET", bytes.Buffer{}, "SecretGetFileSecret", "", "")
+		body, _, technicalError, businessError = secretObj.authenticationObj.HttpClient.CallSecretSafeAPI(url, "GET", bytes.Buffer{}, "SecretGetFileSecret", "", "", "application/json")
 		return technicalError
 	}, secretObj.authenticationObj.ExponentialBackOff)
 
@@ -186,5 +186,189 @@ func (secretObj *SecretObj) SecretGetFileSecret(secretId string, endpointPath st
 
 	responseString := string(responseData)
 	return responseString, nil
+
+}
+
+// CreateSecretCredentialFlow is responsible for creating secrets in Password Safe.
+func (secretObj *SecretObj) CreateSecretFlow(folderTarget string, secretDetails interface{}) (entities.CreateSecretResponse, error) {
+
+	var folder *entities.FolderResponse
+	var createResponse entities.CreateSecretResponse
+
+	secretDetails, err := utils.ValidateCreateSecretInput(secretDetails)
+
+	if err != nil {
+		return createResponse, err
+	}
+
+	folders, err := secretObj.SecretGetFolders("secrets-safe/folders/")
+
+	if err != nil {
+		return createResponse, err
+	}
+
+	for _, v := range folders {
+		if v.Name == strings.TrimSpace(folderTarget) {
+			folder = &v
+			break
+		}
+	}
+
+	if folder == nil {
+		return createResponse, fmt.Errorf("folder %v was not found in folder list", folderTarget)
+	}
+
+	if err != nil {
+		return entities.CreateSecretResponse{}, err
+	}
+
+	createResponse, err = secretObj.SecretCreateSecret(folder.Id, secretDetails)
+
+	if err != nil {
+		return createResponse, err
+	}
+
+	return createResponse, nil
+}
+
+// SecretCreateSecret calls Secret Safe API Requests enpoint to create secrets in Password Safe.
+func (secretObj *SecretObj) SecretCreateSecret(folderId string, secretDetails interface{}) (entities.CreateSecretResponse, error) {
+
+	secretCredentialDetailsJson, err := json.Marshal(secretDetails)
+
+	if err != nil {
+		return entities.CreateSecretResponse{}, err
+	}
+
+	payload := string(secretCredentialDetailsJson)
+
+	secretObj.log.Debug(payload)
+
+	var CreateSecretResponse entities.CreateSecretResponse
+
+	b := bytes.NewBufferString(payload)
+
+	// path depends on the type of secret (credential, text, file).
+	var path string
+	switch secretDetails.(type) {
+	case entities.SecretCredentialDetails:
+		path = "secrets"
+	case entities.SecretTextDetails:
+		path = "secrets/text"
+	case entities.SecretFileDetails:
+		path = "secrets/file"
+	}
+
+	SecretCreateSecreUrl := secretObj.authenticationObj.ApiUrl.JoinPath("secrets-safe/folders", folderId, path).String()
+	messageLog := fmt.Sprintf("%v %v", "POST", SecretCreateSecreUrl)
+	secretObj.log.Debug(messageLog)
+
+	var fileSecret entities.SecretFileDetails
+	var ok bool
+
+	// file secrets have a special behavior, they need to be created using multipart request.
+	if path == "secrets/file" {
+		if fileSecret, ok = secretDetails.(entities.SecretFileDetails); ok {
+			body, err := secretObj.authenticationObj.HttpClient.CreateMultiPartRequest(SecretCreateSecreUrl, fileSecret.FileName, []byte(payload), fileSecret.FileContent)
+			if err != nil {
+				return entities.CreateSecretResponse{}, err
+			}
+
+			defer body.Close()
+			bodyBytes, err := io.ReadAll(body)
+
+			if err != nil {
+				return entities.CreateSecretResponse{}, err
+			}
+
+			err = json.Unmarshal([]byte(bodyBytes), &CreateSecretResponse)
+
+			if err != nil {
+				return entities.CreateSecretResponse{}, err
+			}
+		}
+		return CreateSecretResponse, nil
+	}
+
+	var body io.ReadCloser
+	var technicalError error
+	var businessError error
+
+	technicalError = backoff.Retry(func() error {
+		body, _, technicalError, businessError = secretObj.authenticationObj.HttpClient.CallSecretSafeAPI(SecretCreateSecreUrl, "POST", *b, "SecretCreateSecret", "", "", "application/json")
+		return technicalError
+	}, secretObj.authenticationObj.ExponentialBackOff)
+
+	if technicalError != nil {
+		return entities.CreateSecretResponse{}, technicalError
+	}
+
+	if businessError != nil {
+		return entities.CreateSecretResponse{}, businessError
+	}
+
+	defer body.Close()
+	bodyBytes, err := io.ReadAll(body)
+
+	if err != nil {
+		return entities.CreateSecretResponse{}, err
+	}
+
+	err = json.Unmarshal([]byte(bodyBytes), &CreateSecretResponse)
+
+	if err != nil {
+		secretObj.log.Error(err.Error())
+		return entities.CreateSecretResponse{}, err
+	}
+
+	return CreateSecretResponse, nil
+
+}
+
+// SecretGetFolders call secrets-safe/folders/ enpoint
+// and returns folder list
+func (secretObj *SecretObj) SecretGetFolders(endpointPath string) ([]entities.FolderResponse, error) {
+	messageLog := fmt.Sprintf("%v %v", "GET", endpointPath)
+	secretObj.log.Debug(messageLog + endpointPath)
+
+	var body io.ReadCloser
+	var technicalError error
+	var businessError error
+
+	url := secretObj.authenticationObj.ApiUrl.JoinPath(endpointPath).String()
+
+	var foldersObj []entities.FolderResponse
+
+	technicalError = backoff.Retry(func() error {
+		body, _, technicalError, businessError = secretObj.authenticationObj.HttpClient.CallSecretSafeAPI(url, "GET", bytes.Buffer{}, "SecretGetFolders", "", "", "application/json")
+		return technicalError
+	}, secretObj.authenticationObj.ExponentialBackOff)
+
+	if technicalError != nil {
+		return foldersObj, technicalError
+	}
+
+	if businessError != nil {
+		return foldersObj, businessError
+	}
+
+	defer body.Close()
+	bodyBytes, err := io.ReadAll(body)
+
+	if err != nil {
+		return foldersObj, err
+	}
+
+	err = json.Unmarshal(bodyBytes, &foldersObj)
+	if err != nil {
+		secretObj.log.Error(err.Error())
+		return foldersObj, err
+	}
+
+	if len(foldersObj) == 0 {
+		return foldersObj, fmt.Errorf("empty Folder List")
+	}
+
+	return foldersObj, nil
 
 }

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/gabriel-vasile/mimetype v1.4.3 // indirect
 	github.com/go-playground/locales v0.14.1 // indirect
 	github.com/go-playground/universal-translator v0.18.1 // indirect
+	github.com/google/uuid v1.6.0 // indirect
 	github.com/leodido/go-urn v1.4.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	golang.org/x/crypto v0.22.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -14,6 +14,8 @@ github.com/go-playground/validator/v10 v10.18.0 h1:BvolUXjp4zuvkZ5YN5t7ebzbhlUtP
 github.com/go-playground/validator/v10 v10.18.0/go.mod h1:dbuPbCMFw/DrkbEynArYaCwl3amGuJotoKCe95atGMM=
 github.com/go-playground/validator/v10 v10.19.0 h1:ol+5Fu+cSq9JD7SoSqe04GMI92cbn0+wvQ3bZ8b/AU4=
 github.com/go-playground/validator/v10 v10.19.0/go.mod h1:dbuPbCMFw/DrkbEynArYaCwl3amGuJotoKCe95atGMM=
+github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
+github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/leodido/go-urn v1.4.0 h1:WT9HwE9SGECu3lg4d/dIA+jxlljEa1/ffXKmRjqdmIQ=
 github.com/leodido/go-urn v1.4.0/go.mod h1:bvxc+MVxLKB4z00jd1z+Dvzr47oO32F/QSNjSBOlFxI=
 go.uber.org/multierr v1.10.0 h1:S0h4aNzvfcFsC3dRF1jLoaov7oRaKqRGC/pUEJ2yvPQ=


### PR DESCRIPTION
Add support creating/writing secrets in terraform provider  - repo https://github.com/BeyondTrust/terraform-provider-passwordsafe

Using next endpoints to create secrets and to get folders:

POST Secrets-Safe/Folders/{folderId:guid}/secrets.
POST Secrets-Safe/Folders/{folderId:guid}/secrets/text.
POST Secrets-Safe/Folders/{folderId:guid}/secrets/file.

GET secrets-safe/folders/

User will sends folder name and integration should get folders, search folder in folders list and retrieve folder id to be able to create the secret in that specific folder.