### PR TITLE
feat: add creating folders feature in terraform provider

### DIFF
--- a/TestClient.go
+++ b/TestClient.go
@@ -259,6 +259,22 @@ func main() {
 	// WARNING: Do not log secrets in production code, the following log statement logs test secrets for testing purposes:
 	zapLogger.Debug(fmt.Sprintf("Created File secret: %v", createdSecret.Title))
 
+	folderDetails := entities.FolderDetails{
+		Name:        "FOLDER_" + uuid.New().String(),
+		Description: "My Folder Secret Description",
+	}
+
+	// creating a folder secret in folder1 folder.
+	createdFolder, err := secretObj.CreateFolderFlow("folder1", folderDetails)
+
+	if err != nil {
+		zapLogger.Error(err.Error())
+		return
+	}
+
+	// WARNING: Do not log secrets in production code, the following log statement logs test secrets for testing purposes:
+	zapLogger.Debug(fmt.Sprintf("Created Folder: %v", createdFolder.Name))
+
 	// signing out
 	_ = authenticate.SignOut()
 

--- a/api/authentication/authentication_test.go
+++ b/api/authentication/authentication_test.go
@@ -118,7 +118,7 @@ func TestSignAppinWithApiKey(t *testing.T) {
 
 	var authenticate, _ = AuthenticateUsingApiKey(*httpClientObj, backoffDefinition, "https://fake.api.com:443/BeyondTrust/api/public/v3/", zapLogger, 300, "fake_api_key_")
 	testConfig := UserTestConfig{
-		name: "TestSignAppin",
+		name: "TestSignAppinWithApiKey",
 		server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			_, err := w.Write([]byte(`{"UserId":1, "EmailAddress":"Felipe"}`))
 			if err != nil {

--- a/api/entities/entities.go
+++ b/api/entities/entities.go
@@ -148,3 +148,18 @@ type UrlDetails struct {
 	CredentialId uuid.UUID `json:",omitempty" validate:"omitempty,uuid"`
 	Url          string    `json:",omitempty" validate:"required,max=2048,url"`
 }
+
+type CreateFolderResponse struct {
+	Id          uuid.UUID `json:"id"`
+	Name        string    `json:"name"`
+	Description string    `json:"description"`
+	ParentId    uuid.UUID `json:"parentId"`
+	UserGroupId int       `json:"userGroupId"`
+}
+
+type FolderDetails struct {
+	Name        string    `json:",omitempty" validate:"required"`
+	Description string    `json:",omitempty" validate:"omitempty,max=2048"`
+	ParentId    uuid.UUID `json:",omitempty" validate:"required"`
+	UserGroupId int       `json:",omitempty" validate:"omitempty"`
+}

--- a/api/entities/entities.go
+++ b/api/entities/entities.go
@@ -159,7 +159,7 @@ type CreateFolderResponse struct {
 
 type FolderDetails struct {
 	Name        string    `json:",omitempty" validate:"required"`
-	Description string    `json:",omitempty" validate:"omitempty,max=2048"`
+	Description string    `json:",omitempty" validate:"omitempty,max=256"`
 	ParentId    uuid.UUID `json:",omitempty" validate:"required"`
 	UserGroupId int       `json:",omitempty" validate:"omitempty"`
 }

--- a/api/managed_account/managed_account_test.go
+++ b/api/managed_account/managed_account_test.go
@@ -283,7 +283,7 @@ func TestManageAccountFlowNotFound(t *testing.T) {
 
 	var authenticate, _ = authentication.Authenticate(*httpClientObj, backoffDefinition, "https://fake.api.com:443/BeyondTrust/api/public/v3/", "fakeone_a654+9sdf7+8we4f", "fakeone_aasd156465sfdef", zapLogger, 300)
 	testConfig := ManagedAccountTestConfigStringResponse{
-		name: "TestManageAccountFlowFailedManagedAccounts",
+		name: "TestManageAccountFlowNotFound",
 		server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			// Mocking Response according to the endpoint path
 			switch r.URL.Path {

--- a/api/secrets/secrets_test.go
+++ b/api/secrets/secrets_test.go
@@ -187,7 +187,7 @@ func TestSecretFlow_SecretNotFound(t *testing.T) {
 
 	var authenticate, _ = authentication.Authenticate(*httpClientObj, backoffDefinition, "https://fake.api.com:443/BeyondTrust/api/public/v3/", "fakeone_a654+9sdf7+8we4f", "fakeone_aasd156465sfdef", zapLogger, 300)
 	testConfig := SecretTestConfigStringResponse{
-		name: "TestSecretFlow",
+		name: "TestSecretFlow_SecretNotFound",
 		server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			// Mocking Response according to the endpoint path
 			switch r.URL.Path {
@@ -668,7 +668,7 @@ func TestSecretCreateTextSecretFlow(t *testing.T) {
 
 	var authenticate, _ = authentication.Authenticate(*httpClientObj, backoffDefinition, "https://fake.api.com:443/BeyondTrust/api/public/v3/", "fakeone_a654+9sdf7+8we4f", "fakeone_aasd156465sfdef", zapLogger, 300)
 	testConfig := SecretTestConfigStringResponse{
-		name: "TestSecretCreateSecretFlowFolderNotFound",
+		name: "TestSecretCreateTextSecretFlow",
 		server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			// Mocking Response according to the endpoint path
 			switch r.URL.Path {
@@ -740,7 +740,7 @@ func TestSecretCreateCredentialSecretFlow(t *testing.T) {
 
 	var authenticate, _ = authentication.Authenticate(*httpClientObj, backoffDefinition, "https://fake.api.com:443/BeyondTrust/api/public/v3/", "fakeone_a654+9sdf7+8we4f", "fakeone_aasd156465sfdef", zapLogger, 300)
 	testConfig := SecretTestConfigStringResponse{
-		name: "TestSecretCreateSecretFlowFolderNotFound",
+		name: "TestSecretCreateCredentialSecretFlow",
 		server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			// Mocking Response according to the endpoint path
 			switch r.URL.Path {
@@ -812,7 +812,7 @@ func TestSecretCreateFileSecretFlow(t *testing.T) {
 
 	var authenticate, _ = authentication.Authenticate(*httpClientObj, backoffDefinition, "https://fake.api.com:443/BeyondTrust/api/public/v3/", "fakeone_a654+9sdf7+8we4f", "fakeone_aasd156465sfdef", zapLogger, 300)
 	testConfig := SecretTestConfigStringResponse{
-		name: "TestSecretCreateSecretFlowFolderNotFound",
+		name: "TestSecretCreateFileSecretFlow",
 		server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			// Mocking Response according to the endpoint path
 			switch r.URL.Path {
@@ -884,7 +884,7 @@ func TestSecretCreateFileSecretFlowError(t *testing.T) {
 
 	var authenticate, _ = authentication.Authenticate(*httpClientObj, backoffDefinition, "https://fake.api.com:443/BeyondTrust/api/public/v3/", "fakeone_a654+9sdf7+8we4f", "fakeone_aasd156465sfdef", zapLogger, 300)
 	testConfig := SecretTestConfigStringResponse{
-		name: "TestSecretCreateSecretFlowFolderNotFound",
+		name: "TestSecretCreateFileSecretFlowError",
 		server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			// Mocking Response according to the endpoint path
 			switch r.URL.Path {
@@ -954,7 +954,7 @@ func TestSecretCreateBadInput(t *testing.T) {
 
 	var authenticate, _ = authentication.Authenticate(*httpClientObj, backoffDefinition, "https://fake.api.com:443/BeyondTrust/api/public/v3/", "fakeone_a654+9sdf7+8we4f", "fakeone_aasd156465sfdef", zapLogger, 300)
 	testConfig := SecretTestConfigStringResponse{
-		name: "TestSecretCreateSecretFlowFolderNotFound",
+		name: "TestSecretCreateBadInput",
 		server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			// Mocking Response according to the endpoint path
 			switch r.URL.Path {
@@ -1078,7 +1078,7 @@ func TestSecretCreateSecretFlowEmptyFolderList(t *testing.T) {
 
 	var authenticate, _ = authentication.Authenticate(*httpClientObj, backoffDefinition, "https://fake.api.com:443/BeyondTrust/api/public/v3/", "fakeone_a654+9sdf7+8we4f", "fakeone_aasd156465sfdef", zapLogger, 300)
 	testConfig := SecretTestConfigStringResponse{
-		name: "TestSecretCreateSecretFlowFolderNotFound",
+		name: "TestSecretCreateSecretFlowEmptyFolderList",
 		server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			// Mocking Response according to the endpoint path
 			switch r.URL.Path {
@@ -1122,4 +1122,116 @@ func TestSecretCreateSecretFlowEmptyFolderList(t *testing.T) {
 		t.Errorf("Test case Failed %v, %v", err.Error(), testConfig.response)
 	}
 
+}
+
+func TestSecretFolderFlow(t *testing.T) {
+	logger, _ := zap.NewDevelopment()
+
+	// create a zap logger wrapper
+	zapLogger := logging.NewZapLogger(logger)
+
+	httpClientObj, _ := utils.GetHttpClient(5, false, "", "", zapLogger)
+
+	backoffDefinition := backoff.NewExponentialBackOff()
+	backoffDefinition.MaxElapsedTime = time.Second
+
+	var authenticate, _ = authentication.Authenticate(*httpClientObj, backoffDefinition, "https://fake.api.com:443/BeyondTrust/api/public/v3/", "fakeone_a654+9sdf7+8we4f", "fakeone_aasd156465sfdef", zapLogger, 300)
+	testConfig := SecretTestConfigStringResponse{
+		name: "TestSecretFolderFlow",
+		server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+
+			// Mocking Response according to the endpoint path
+			if r.URL.Path == "/secrets-safe/folders/" && r.Method == "GET" {
+				_, err := w.Write([]byte(`[{"Id": "cb871861-8b40-4556-820c-1ca6d522adfa","Name": "folder1"}, {"Id": "a4af73dc-4e89-41ec-eb9a-08dcf22d3aba","Name": "folder2"}]`))
+				if err != nil {
+					t.Error("Test case Failed")
+				}
+			}
+			if r.URL.Path == "/secrets-safe/folders/" && r.Method == "POST" {
+				_, err := w.Write([]byte(`{"Id": "cb871861-8b40-4556-820c-1ca6d522adfa","Name": "Folder Title", "Description": "Folder Description"}`))
+				if err != nil {
+					t.Error("Test case Failed")
+				}
+			}
+		})),
+	}
+
+	apiUrl, _ := url.Parse(testConfig.server.URL + "/")
+	authenticate.ApiUrl = *apiUrl
+	secretObj, _ := NewSecretObj(*authenticate, zapLogger, 4000)
+
+	folderDetails := entities.FolderDetails{
+		Name:        "FOLDER_" + uuid.New().String(),
+		Description: "My Folder Description",
+	}
+
+	response, err := secretObj.CreateFolderFlow("folder1", folderDetails)
+
+	if response.Name != "Folder Title" {
+		t.Errorf("Test case Failed %v, %v", response.Name, "Folder Title")
+	}
+
+	if response.Description != "Folder Description" {
+		t.Errorf("Test case Failed %v, %v", response.Description, "Folder Description")
+	}
+
+	if err != nil {
+		t.Errorf("Test case Failed: %v", err)
+	}
+}
+
+func TestSecretFolderFlowBadParentFolder(t *testing.T) {
+	logger, _ := zap.NewDevelopment()
+
+	// create a zap logger wrapper
+	zapLogger := logging.NewZapLogger(logger)
+
+	httpClientObj, _ := utils.GetHttpClient(5, false, "", "", zapLogger)
+
+	backoffDefinition := backoff.NewExponentialBackOff()
+	backoffDefinition.MaxElapsedTime = time.Second
+
+	var authenticate, _ = authentication.Authenticate(*httpClientObj, backoffDefinition, "https://fake.api.com:443/BeyondTrust/api/public/v3/", "fakeone_a654+9sdf7+8we4f", "fakeone_aasd156465sfdef", zapLogger, 300)
+	testConfig := SecretTestConfigStringResponse{
+		name: "TestSecretFolderFlowBadParentFolder",
+		server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+
+			// Mocking Response according to the endpoint path
+			if r.URL.Path == "/secrets-safe/folders/" && r.Method == "GET" {
+				_, err := w.Write([]byte(`[{"Id": "cb871861-8b40-4556-820c-1ca6d522adfa","Name": "folder1"}, {"Id": "a4af73dc-4e89-41ec-eb9a-08dcf22d3aba","Name": "folder2"}]`))
+				if err != nil {
+					t.Error("Test case Failed")
+				}
+			} else if r.URL.Path == "/secrets-safe/folders/" && r.Method == "POST" {
+				w.WriteHeader(http.StatusBadRequest)
+				_, err := w.Write([]byte(`{"error": "InvalidFolderName"}`))
+				if err != nil {
+					t.Error("Test case Failed")
+				}
+			} else {
+				http.NotFound(w, r)
+			}
+
+		})),
+	}
+
+	apiUrl, _ := url.Parse(testConfig.server.URL + "/")
+	authenticate.ApiUrl = *apiUrl
+	secretObj, _ := NewSecretObj(*authenticate, zapLogger, 4000)
+
+	folderDetails := entities.FolderDetails{
+		Name:        "FOLDER_" + uuid.New().String(),
+		Description: "My Folder Description",
+	}
+
+	_, err := secretObj.CreateFolderFlow("folder1", folderDetails)
+
+	expetedErrorMessage := `error - status code: 400 - {"error": "InvalidFolderName"}`
+
+	if err.Error() != expetedErrorMessage {
+		t.Errorf("Test case Failed %v, %v", err.Error(), expetedErrorMessage)
+	}
+	if err == nil {
+		t.Errorf("Test case Failed: %v", err)
+	}
 }

--- a/api/utils/validator.go
+++ b/api/utils/validator.go
@@ -284,3 +284,15 @@ func formatErrorMessage(err validator.FieldError) string {
 		return fmt.Sprintf("Error en el campo '%s': %s.", err.Field(), err.Tag())
 	}
 }
+
+// ValidateCreateFolderInput responsible for validating folder input.
+func ValidateCreateFolderInput(folderDetails entities.FolderDetails) (entities.FolderDetails, error) {
+	validate := validator.New()
+	err := validate.Struct(folderDetails)
+	if err != nil {
+		for _, err := range err.(validator.ValidationErrors) {
+			return folderDetails, errors.New(formatErrorMessage(err))
+		}
+	}
+	return folderDetails, nil
+}


### PR DESCRIPTION
Add support creating/writing folders in terraform provider  - repo [BeyondTrust/terraform-provider-passwordsafe](https://github.com/BeyondTrust/terraform-provider-passwordsafe) 

Using next endpoints to create folders and to get possible parent folders:

POST Secrets-Safe/Folders/

GET Secrets-Safe/Folders/

User will send the parent folder name and integration should get folders, search parent folder name in folders list and retrieve folder id to be able to create new folder with that specific parent folder Id.

Parent Folder should be exist in Password Safe.