### PR TITLE
feat: improve  authenticate method parameters

### DIFF
--- a/TestClient.go
+++ b/TestClient.go
@@ -57,6 +57,7 @@ func main() {
 		ClientID:                   clientId,
 		ClientSecret:               clientSecret,
 		ApiUrl:                     &apiUrl,
+		ApiVersion:                 apiVersion,
 		ClientTimeOutInSeconds:     clientTimeOutInSeconds,
 		Separator:                  &separator,
 		VerifyCa:                   verifyCa,
@@ -77,8 +78,20 @@ func main() {
 	// creating a http client
 	httpClientObj, _ := utils.GetHttpClient(clientTimeOutInSeconds, verifyCa, certificate, certificateKey, zapLogger)
 
-	// instantiating authenticate obj, injecting httpClient object
-	authenticate, _ := authentication.Authenticate(*httpClientObj, backoffDefinition, apiUrl, apiVersion, clientId, clientSecret, zapLogger, retryMaxElapsedTimeMinutes)
+	authParams := authentication.AuthenticationParametersObj{
+		HTTPClient:                 *httpClientObj,
+		BackoffDefinition:          backoffDefinition,
+		EndpointURL:                apiUrl,
+		APIVersion:                 apiVersion,
+		ClientID:                   clientId,
+		ClientSecret:               clientSecret,
+		ApiKey:                     "fakeone_a654+9sdf7+8we4f",
+		Logger:                     zapLogger,
+		RetryMaxElapsedTimeSeconds: 30,
+	}
+
+	// instantiating authenticate obj
+	authenticate, _ := authentication.AuthenticateUsingApiKey(authParams)
 
 	// authenticating
 	userObject, err := authenticate.GetPasswordSafeAuthentication()

--- a/api/authentication/authentication.go
+++ b/api/authentication/authentication.go
@@ -28,20 +28,36 @@ type AuthenticationObj struct {
 	log                logging.Logger
 }
 
+type AuthenticationParametersObj struct {
+	HTTPClient                 utils.HttpClientObj
+	BackoffDefinition          *backoff.ExponentialBackOff
+	EndpointURL                string
+	APIVersion                 string
+	ClientID                   string
+	ClientSecret               string
+	ApiKey                     string
+	Logger                     logging.Logger
+	RetryMaxElapsedTimeSeconds int
+}
+
 // Authenticate is responsible for Auth configuration using Client Id and Client secret.
 // Prerequisites - use input validation methods before using this class.
-func Authenticate(httpClient utils.HttpClientObj, backoffDefinition *backoff.ExponentialBackOff, endpointUrl string, apiVersion string, clientId string, clientSecret string, logger logging.Logger, retryMaxElapsedTimeSeconds int) (*AuthenticationObj, error) {
+func Authenticate(authenticationParametersObj AuthenticationParametersObj) (*AuthenticationObj, error) {
 
-	apiUrl, _ := url.Parse(endpointUrl)
+	apiUrl, err := url.Parse(authenticationParametersObj.EndpointURL)
+	if err != nil {
+		return nil, err
+	}
+
 	authenticationObj := &AuthenticationObj{
 		ApiUrl:             *apiUrl,
-		ApiVersion:         apiVersion,
-		HttpClient:         httpClient,
-		clientId:           clientId,
-		clientSecret:       clientSecret,
+		ApiVersion:         authenticationParametersObj.APIVersion,
+		HttpClient:         authenticationParametersObj.HTTPClient,
+		clientId:           authenticationParametersObj.ClientID,
+		clientSecret:       authenticationParametersObj.ClientSecret,
 		apiKey:             "",
-		ExponentialBackOff: backoffDefinition,
-		log:                logger,
+		ExponentialBackOff: authenticationParametersObj.BackoffDefinition,
+		log:                authenticationParametersObj.Logger,
 	}
 
 	authenticationObj.log.Debug("Signing in using Oauth")
@@ -50,18 +66,21 @@ func Authenticate(httpClient utils.HttpClientObj, backoffDefinition *backoff.Exp
 
 // AuthenticateUsingApiKey is responsible for Auth configuration using API Key.
 // Prerequisites - use input validation methods before using this class.
-func AuthenticateUsingApiKey(httpClient utils.HttpClientObj, backoffDefinition *backoff.ExponentialBackOff, endpointUrl string, apiVersion string, logger logging.Logger, retryMaxElapsedTimeSeconds int, apiKey string) (*AuthenticationObj, error) {
+func AuthenticateUsingApiKey(authenticationParametersObj AuthenticationParametersObj) (*AuthenticationObj, error) {
 
-	apiUrl, _ := url.Parse(endpointUrl)
+	apiUrl, err := url.Parse(authenticationParametersObj.EndpointURL)
+	if err != nil {
+		return nil, err
+	}
 	authenticationObj := &AuthenticationObj{
 		ApiUrl:             *apiUrl,
-		ApiVersion:         apiVersion,
-		HttpClient:         httpClient,
+		ApiVersion:         authenticationParametersObj.APIVersion,
+		HttpClient:         authenticationParametersObj.HTTPClient,
 		clientId:           "",
 		clientSecret:       "",
-		apiKey:             apiKey,
-		ExponentialBackOff: backoffDefinition,
-		log:                logger,
+		apiKey:             authenticationParametersObj.ApiKey,
+		ExponentialBackOff: authenticationParametersObj.BackoffDefinition,
+		log:                authenticationParametersObj.Logger,
 	}
 	authenticationObj.log.Debug("Signing in using API Key")
 	return authenticationObj, nil

--- a/api/managed_account/managed_account_test.go
+++ b/api/managed_account/managed_account_test.go
@@ -43,19 +43,38 @@ type CreateManagedAccountsResponse struct {
 // the default API version 3.0 will be used
 var apiVersion string = "3.1"
 
-func TestManagedAccountGet(t *testing.T) {
+var authParams *authentication.AuthenticationParametersObj
+var zapLogger *logging.ZapLogger
+
+func InitializeGlobalConfig() {
 
 	logger, _ := zap.NewDevelopment()
 
-	// create a zap logger wrapper
-	zapLogger := logging.NewZapLogger(logger)
+	zapLogger = logging.NewZapLogger(logger)
 
 	httpClientObj, _ := utils.GetHttpClient(5, false, "", "", zapLogger)
 
 	backoffDefinition := backoff.NewExponentialBackOff()
 	backoffDefinition.MaxElapsedTime = time.Second
 
-	var authenticate, _ = authentication.Authenticate(*httpClientObj, backoffDefinition, "https://fake.api.com:443/BeyondTrust/api/public/v3/", apiVersion, "fakeone_a654+9sdf7+8we4f", "fakeone_aasd156465sfdef", zapLogger, 300)
+	authParams = &authentication.AuthenticationParametersObj{
+		HTTPClient:                 *httpClientObj,
+		BackoffDefinition:          backoffDefinition,
+		EndpointURL:                "https://fake.api.com:443/BeyondTrust/api/public/v3/",
+		APIVersion:                 apiVersion,
+		ClientID:                   "fakeone_a654+9sdf7+8we4f",
+		ClientSecret:               "fakeone_a654+9sdf7+8we4f",
+		ApiKey:                     "",
+		Logger:                     zapLogger,
+		RetryMaxElapsedTimeSeconds: 300,
+	}
+}
+
+func TestManagedAccountGet(t *testing.T) {
+
+	InitializeGlobalConfig()
+
+	var authenticate, _ = authentication.Authenticate(*authParams)
 
 	testConfig := ManagedAccountTestConfig{
 		name: "TestManagedAccountGet",
@@ -87,17 +106,8 @@ func TestManagedAccountGet(t *testing.T) {
 }
 
 func TestManagedAccountCreateRequest(t *testing.T) {
-	logger, _ := zap.NewDevelopment()
 
-	// create a zap logger wrapper
-	zapLogger := logging.NewZapLogger(logger)
-
-	httpClientObj, _ := utils.GetHttpClient(5, false, "", "", zapLogger)
-
-	backoffDefinition := backoff.NewExponentialBackOff()
-	backoffDefinition.MaxElapsedTime = time.Second
-
-	var authenticate, _ = authentication.Authenticate(*httpClientObj, backoffDefinition, "https://fake.api.com:443/BeyondTrust/api/public/v3/", apiVersion, "fakeone_a654+9sdf7+8we4f", "fakeone_aasd156465sfdef", zapLogger, 300)
+	var authenticate, _ = authentication.Authenticate(*authParams)
 	testConfig := ManagedAccountTestConfigStringResponse{
 		name: "TestManagedAccountCreateRequest",
 		server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -124,17 +134,8 @@ func TestManagedAccountCreateRequest(t *testing.T) {
 }
 
 func TestCredentialByRequestId(t *testing.T) {
-	logger, _ := zap.NewDevelopment()
 
-	// create a zap logger wrapper
-	zapLogger := logging.NewZapLogger(logger)
-
-	httpClientObj, _ := utils.GetHttpClient(5, false, "", "", zapLogger)
-
-	backoffDefinition := backoff.NewExponentialBackOff()
-	backoffDefinition.MaxElapsedTime = time.Second
-
-	var authenticate, _ = authentication.Authenticate(*httpClientObj, backoffDefinition, "https://fake.api.com:443/BeyondTrust/api/public/v3/", apiVersion, "fakeone_a654+9sdf7+8we4f", "fakeone_aasd156465sfdef", zapLogger, 300)
+	var authenticate, _ = authentication.Authenticate(*authParams)
 	testConfig := ManagedAccountTestConfigStringResponse{
 		name: "TestCredentialByRequestId",
 		server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -161,17 +162,8 @@ func TestCredentialByRequestId(t *testing.T) {
 }
 
 func TestManagedAccountRequestCheckIn(t *testing.T) {
-	logger, _ := zap.NewDevelopment()
 
-	// create a zap logger wrapper
-	zapLogger := logging.NewZapLogger(logger)
-
-	httpClientObj, _ := utils.GetHttpClient(5, false, "", "", zapLogger)
-
-	backoffDefinition := backoff.NewExponentialBackOff()
-	backoffDefinition.MaxElapsedTime = time.Second
-
-	var authenticate, _ = authentication.Authenticate(*httpClientObj, backoffDefinition, "https://fake.api.com:443/BeyondTrust/api/public/v3/", apiVersion, "fakeone_a654+9sdf7+8we4f", "fakeone_aasd156465sfdef", zapLogger, 300)
+	var authenticate, _ = authentication.Authenticate(*authParams)
 	testConfig := ManagedAccountTestConfigStringResponse{
 		name: "TestManagedAccountRequestCheckIn",
 		server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -198,17 +190,8 @@ func TestManagedAccountRequestCheckIn(t *testing.T) {
 }
 
 func TestManageAccountFlow(t *testing.T) {
-	logger, _ := zap.NewDevelopment()
 
-	// create a zap logger wrapper
-	zapLogger := logging.NewZapLogger(logger)
-
-	httpClientObj, _ := utils.GetHttpClient(5, false, "", "", zapLogger)
-
-	backoffDefinition := backoff.NewExponentialBackOff()
-	backoffDefinition.MaxElapsedTime = time.Second
-
-	var authenticate, _ = authentication.Authenticate(*httpClientObj, backoffDefinition, "https://fake.api.com:443/BeyondTrust/api/public/v3/", apiVersion, "fakeone_a654+9sdf7+8we4f", "fakeone_aasd156465sfdef", zapLogger, 300)
+	var authenticate, _ = authentication.Authenticate(*authParams)
 	testConfig := ManagedAccountTestConfigStringResponse{
 		name: "TestManageAccountFlow",
 		server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -275,17 +258,8 @@ func TestManageAccountFlow(t *testing.T) {
 }
 
 func TestManageAccountFlowNotFound(t *testing.T) {
-	logger, _ := zap.NewDevelopment()
 
-	// create a zap logger wrapper
-	zapLogger := logging.NewZapLogger(logger)
-
-	httpClientObj, _ := utils.GetHttpClient(5, false, "", "", zapLogger)
-
-	backoffDefinition := backoff.NewExponentialBackOff()
-	backoffDefinition.MaxElapsedTime = time.Second
-
-	var authenticate, _ = authentication.Authenticate(*httpClientObj, backoffDefinition, "https://fake.api.com:443/BeyondTrust/api/public/v3/", apiVersion, "fakeone_a654+9sdf7+8we4f", "fakeone_aasd156465sfdef", zapLogger, 300)
+	var authenticate, _ = authentication.Authenticate(*authParams)
 	testConfig := ManagedAccountTestConfigStringResponse{
 		name: "TestManageAccountFlowNotFound",
 		server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -352,17 +326,8 @@ func TestManageAccountFlowNotFound(t *testing.T) {
 }
 
 func TestSecretGetSecret(t *testing.T) {
-	logger, _ := zap.NewDevelopment()
 
-	// create a zap logger wrapper
-	zapLogger := logging.NewZapLogger(logger)
-
-	httpClientObj, _ := utils.GetHttpClient(5, false, "", "", zapLogger)
-
-	backoffDefinition := backoff.NewExponentialBackOff()
-	backoffDefinition.MaxElapsedTime = time.Second
-
-	var authenticate, _ = authentication.Authenticate(*httpClientObj, backoffDefinition, "https://fake.api.com:443/BeyondTrust/api/public/v3/", apiVersion, "fakeone_a654+9sdf7+8we4f", "fakeone_aasd156465sfdef", zapLogger, 300)
+	var authenticate, _ = authentication.Authenticate(*authParams)
 	testConfig := ManagedAccountTestConfigStringResponse{
 		name: "TestSecretGetSecret",
 		server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -427,17 +392,8 @@ func TestSecretGetSecret(t *testing.T) {
 }
 
 func TestSecretGetSecrets(t *testing.T) {
-	logger, _ := zap.NewDevelopment()
 
-	// create a zap logger wrapper
-	zapLogger := logging.NewZapLogger(logger)
-
-	httpClientObj, _ := utils.GetHttpClient(5, false, "", "", zapLogger)
-
-	backoffDefinition := backoff.NewExponentialBackOff()
-	backoffDefinition.MaxElapsedTime = time.Second
-
-	var authenticate, _ = authentication.Authenticate(*httpClientObj, backoffDefinition, "https://fake.api.com:443/BeyondTrust/api/public/v3/", apiVersion, "fakeone_a654+9sdf7+8we4f", "fakeone_aasd156465sfdef", zapLogger, 300)
+	var authenticate, _ = authentication.Authenticate(*authParams)
 	testConfig := ManagedAccountTestConfigStringResponse{
 		name: "TestSecretGetSecrets",
 		server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -503,17 +459,8 @@ func TestSecretGetSecrets(t *testing.T) {
 }
 
 func TestManagedAccountFlowTechnicalErrorCreatingRequest(t *testing.T) {
-	logger, _ := zap.NewDevelopment()
 
-	// create a zap logger wrapper
-	zapLogger := logging.NewZapLogger(logger)
-
-	httpClientObj, _ := utils.GetHttpClient(5, false, "", "", zapLogger)
-
-	backoffDefinition := backoff.NewExponentialBackOff()
-	backoffDefinition.MaxElapsedTime = time.Second
-
-	var authenticate, _ = authentication.Authenticate(*httpClientObj, backoffDefinition, "https://fake.api.com:443/BeyondTrust/api/public/v3/", apiVersion, "fakeone_a654+9sdf7+8we4f", "fakeone_aasd156465sfdef", zapLogger, 300)
+	var authenticate, _ = authentication.Authenticate(*authParams)
 	testConfig := ManagedAccountTestConfigStringResponse{
 		name: "TestManagedAccountFlowTechnicalErrorCreatingRequest",
 		server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -578,17 +525,8 @@ func TestManagedAccountFlowTechnicalErrorCreatingRequest(t *testing.T) {
 }
 
 func TestManagedAccountFlowBusinesslErrorCreatingRequest(t *testing.T) {
-	logger, _ := zap.NewDevelopment()
 
-	// create a zap logger wrapper
-	zapLogger := logging.NewZapLogger(logger)
-
-	httpClientObj, _ := utils.GetHttpClient(5, false, "", "", zapLogger)
-
-	backoffDefinition := backoff.NewExponentialBackOff()
-	backoffDefinition.MaxElapsedTime = time.Second
-
-	var authenticate, _ = authentication.Authenticate(*httpClientObj, backoffDefinition, "https://fake.api.com:443/BeyondTrust/api/public/v3/", apiVersion, "fakeone_a654+9sdf7+8we4f", "fakeone_aasd156465sfdef", zapLogger, 300)
+	var authenticate, _ = authentication.Authenticate(*authParams)
 	testConfig := ManagedAccountTestConfigStringResponse{
 		name: "TestManagedAccountFlowBusinesslErrorCreatingRequest",
 		server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -653,17 +591,8 @@ func TestManagedAccountFlowBusinesslErrorCreatingRequest(t *testing.T) {
 }
 
 func TestManagedAccountFlowTechnicalErrorCredentialByRequestId(t *testing.T) {
-	logger, _ := zap.NewDevelopment()
 
-	// create a zap logger wrapper
-	zapLogger := logging.NewZapLogger(logger)
-
-	httpClientObj, _ := utils.GetHttpClient(5, false, "", "", zapLogger)
-
-	backoffDefinition := backoff.NewExponentialBackOff()
-	backoffDefinition.MaxElapsedTime = time.Second
-
-	var authenticate, _ = authentication.Authenticate(*httpClientObj, backoffDefinition, "https://fake.api.com:443/BeyondTrust/api/public/v3/", apiVersion, "fakeone_a654+9sdf7+8we4f", "fakeone_aasd156465sfdef", zapLogger, 300)
+	var authenticate, _ = authentication.Authenticate(*authParams)
 	testConfig := ManagedAccountTestConfigStringResponse{
 		name: "TestManagedAccountFlowTechnicalErrorCredentialByRequestId",
 		server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -728,17 +657,8 @@ func TestManagedAccountFlowTechnicalErrorCredentialByRequestId(t *testing.T) {
 }
 
 func TestManagedAccountFlowBusinessErrorCredentialByRequestId(t *testing.T) {
-	logger, _ := zap.NewDevelopment()
 
-	// create a zap logger wrapper
-	zapLogger := logging.NewZapLogger(logger)
-
-	httpClientObj, _ := utils.GetHttpClient(5, false, "", "", zapLogger)
-
-	backoffDefinition := backoff.NewExponentialBackOff()
-	backoffDefinition.MaxElapsedTime = time.Second
-
-	var authenticate, _ = authentication.Authenticate(*httpClientObj, backoffDefinition, "https://fake.api.com:443/BeyondTrust/api/public/v3/", apiVersion, "fakeone_a654+9sdf7+8we4f", "fakeone_aasd156465sfdef", zapLogger, 300)
+	var authenticate, _ = authentication.Authenticate(*authParams)
 	testConfig := ManagedAccountTestConfigStringResponse{
 		name: "TestManagedAccountFlowBusinessErrorCredentialByRequestId",
 		server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -803,17 +723,8 @@ func TestManagedAccountFlowBusinessErrorCredentialByRequestId(t *testing.T) {
 }
 
 func TestManagedAccountFlowBusinessErrorAccountRequestCheckIn(t *testing.T) {
-	logger, _ := zap.NewDevelopment()
 
-	// create a zap logger wrapper
-	zapLogger := logging.NewZapLogger(logger)
-
-	httpClientObj, _ := utils.GetHttpClient(5, false, "", "", zapLogger)
-
-	backoffDefinition := backoff.NewExponentialBackOff()
-	backoffDefinition.MaxElapsedTime = time.Second
-
-	var authenticate, _ = authentication.Authenticate(*httpClientObj, backoffDefinition, "https://fake.api.com:443/BeyondTrust/api/public/v3/", apiVersion, "fakeone_a654+9sdf7+8we4f", "fakeone_aasd156465sfdef", zapLogger, 300)
+	var authenticate, _ = authentication.Authenticate(*authParams)
 	testConfig := ManagedAccountTestConfigStringResponse{
 		name: "TestManagedAccountFlowBusinessErrorAccountRequestCheckIn",
 		server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -878,17 +789,8 @@ func TestManagedAccountFlowBusinessErrorAccountRequestCheckIn(t *testing.T) {
 }
 
 func TestManagedAccountFlowTechnicalErrorAccountRequestCheckIn(t *testing.T) {
-	logger, _ := zap.NewDevelopment()
 
-	// create a zap logger wrapper
-	zapLogger := logging.NewZapLogger(logger)
-
-	httpClientObj, _ := utils.GetHttpClient(5, false, "", "", zapLogger)
-
-	backoffDefinition := backoff.NewExponentialBackOff()
-	backoffDefinition.MaxElapsedTime = time.Second
-
-	var authenticate, _ = authentication.Authenticate(*httpClientObj, backoffDefinition, "https://fake.api.com:443/BeyondTrust/api/public/v3/", apiVersion, "fakeone_a654+9sdf7+8we4f", "fakeone_aasd156465sfdef", zapLogger, 300)
+	var authenticate, _ = authentication.Authenticate(*authParams)
 	testConfig := ManagedAccountTestConfigStringResponse{
 		name: "TestManagedAccountFlowTechnicalErrorAccountRequestCheckIn",
 		server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -953,17 +855,8 @@ func TestManagedAccountFlowTechnicalErrorAccountRequestCheckIn(t *testing.T) {
 }
 
 func TestManagedAccountFlowGetAccountTechnicalError(t *testing.T) {
-	logger, _ := zap.NewDevelopment()
 
-	// create a zap logger wrapper
-	zapLogger := logging.NewZapLogger(logger)
-
-	httpClientObj, _ := utils.GetHttpClient(5, false, "", "", zapLogger)
-
-	backoffDefinition := backoff.NewExponentialBackOff()
-	backoffDefinition.MaxElapsedTime = time.Second
-
-	var authenticate, _ = authentication.Authenticate(*httpClientObj, backoffDefinition, "https://fake.api.com:443/BeyondTrust/api/public/v3/", apiVersion, "fakeone_a654+9sdf7+8we4f", "fakeone_aasd156465sfdef", zapLogger, 300)
+	var authenticate, _ = authentication.Authenticate(*authParams)
 	testConfig := ManagedAccountTestConfigStringResponse{
 		name: "TestManagedAccountFlowGetAccountTechnicalError",
 		server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -1009,17 +902,8 @@ func TestManagedAccountFlowGetAccountTechnicalError(t *testing.T) {
 }
 
 func TestManageAccountFlowGetAccountBadResponse(t *testing.T) {
-	logger, _ := zap.NewDevelopment()
 
-	// create a zap logger wrapper
-	zapLogger := logging.NewZapLogger(logger)
-
-	httpClientObj, _ := utils.GetHttpClient(5, false, "", "", zapLogger)
-
-	backoffDefinition := backoff.NewExponentialBackOff()
-	backoffDefinition.MaxElapsedTime = time.Second
-
-	var authenticate, _ = authentication.Authenticate(*httpClientObj, backoffDefinition, "https://fake.api.com:443/BeyondTrust/api/public/v3/", apiVersion, "fakeone_a654+9sdf7+8we4f", "fakeone_aasd156465sfdef", zapLogger, 300)
+	var authenticate, _ = authentication.Authenticate(*authParams)
 	testConfig := ManagedAccountTestConfigStringResponse{
 		name: "TestManageAccountFlowGetAccountBadResponse",
 		server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -1064,17 +948,8 @@ func TestManageAccountFlowGetAccountBadResponse(t *testing.T) {
 }
 
 func TestManagedAccountCreateManagedAccount(t *testing.T) {
-	logger, _ := zap.NewDevelopment()
 
-	// create a zap logger wrapper
-	zapLogger := logging.NewZapLogger(logger)
-
-	httpClientObj, _ := utils.GetHttpClient(5, false, "", "", zapLogger)
-
-	backoffDefinition := backoff.NewExponentialBackOff()
-	backoffDefinition.MaxElapsedTime = time.Second
-
-	var authenticate, _ = authentication.Authenticate(*httpClientObj, backoffDefinition, "https://fake.api.com:443/BeyondTrust/api/public/v3/", apiVersion, "fakeone_a654+9sdf7+8we4f", "fakeone_aasd156465sfdef", zapLogger, 300)
+	var authenticate, _ = authentication.Authenticate(*authParams)
 	testConfig := CreateManagedAccountsResponse{
 		name: "TestManagedAccountCreateManagedAccount",
 		server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -1126,17 +1001,8 @@ func TestManagedAccountCreateManagedAccount(t *testing.T) {
 }
 
 func TestManagedAccountCreateManagedAccountExistingOne(t *testing.T) {
-	logger, _ := zap.NewDevelopment()
 
-	// create a zap logger wrapper
-	zapLogger := logging.NewZapLogger(logger)
-
-	httpClientObj, _ := utils.GetHttpClient(5, false, "", "", zapLogger)
-
-	backoffDefinition := backoff.NewExponentialBackOff()
-	backoffDefinition.MaxElapsedTime = time.Second
-
-	var authenticate, _ = authentication.Authenticate(*httpClientObj, backoffDefinition, "https://fake.api.com:443/BeyondTrust/api/public/v3/", apiVersion, "fakeone_a654+9sdf7+8we4f", "fakeone_aasd156465sfdef", zapLogger, 300)
+	var authenticate, _ = authentication.Authenticate(*authParams)
 	testConfig := ManagedAccountTestConfigStringResponse{
 		name: "TestManagedAccountCreateManagedAccountExistingOne",
 		server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -1179,17 +1045,8 @@ func TestManagedAccountCreateManagedAccountExistingOne(t *testing.T) {
 }
 
 func TestManagedAccountCreateManagedAccountFlow(t *testing.T) {
-	logger, _ := zap.NewDevelopment()
 
-	// create a zap logger wrapper
-	zapLogger := logging.NewZapLogger(logger)
-
-	httpClientObj, _ := utils.GetHttpClient(5, false, "", "", zapLogger)
-
-	backoffDefinition := backoff.NewExponentialBackOff()
-	backoffDefinition.MaxElapsedTime = time.Second
-
-	var authenticate, _ = authentication.Authenticate(*httpClientObj, backoffDefinition, "https://fake.api.com:443/BeyondTrust/api/public/v3/", apiVersion, "fakeone_a654+9sdf7+8we4f", "fakeone_aasd156465sfdef", zapLogger, 300)
+	var authenticate, _ = authentication.Authenticate(*authParams)
 	testConfig := CreateManagedAccountsResponse{
 		name: "TestManagedAccountCreateManagedAccountFlow",
 		server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -1245,17 +1102,8 @@ func TestManagedAccountCreateManagedAccountFlow(t *testing.T) {
 }
 
 func TestManagedAccountCreateManagedAccountFlowSystemNotFound(t *testing.T) {
-	logger, _ := zap.NewDevelopment()
 
-	// create a zap logger wrapper
-	zapLogger := logging.NewZapLogger(logger)
-
-	httpClientObj, _ := utils.GetHttpClient(5, false, "", "", zapLogger)
-
-	backoffDefinition := backoff.NewExponentialBackOff()
-	backoffDefinition.MaxElapsedTime = time.Second
-
-	var authenticate, _ = authentication.Authenticate(*httpClientObj, backoffDefinition, "https://fake.api.com:443/BeyondTrust/api/public/v3/", apiVersion, "fakeone_a654+9sdf7+8we4f", "fakeone_aasd156465sfdef", zapLogger, 300)
+	var authenticate, _ = authentication.Authenticate(*authParams)
 	testConfig := ManagedAccountTestConfigStringResponse{
 		name: "TestManagedAccountCreateManagedAccountFlowSystemNotFound",
 		server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -1304,17 +1152,8 @@ func TestManagedAccountCreateManagedAccountFlowSystemNotFound(t *testing.T) {
 }
 
 func TestManagedAccountCreateManagedAccountFlowEmptySystemList(t *testing.T) {
-	logger, _ := zap.NewDevelopment()
 
-	// create a zap logger wrapper
-	zapLogger := logging.NewZapLogger(logger)
-
-	httpClientObj, _ := utils.GetHttpClient(5, false, "", "", zapLogger)
-
-	backoffDefinition := backoff.NewExponentialBackOff()
-	backoffDefinition.MaxElapsedTime = time.Second
-
-	var authenticate, _ = authentication.Authenticate(*httpClientObj, backoffDefinition, "https://fake.api.com:443/BeyondTrust/api/public/v3/", apiVersion, "fakeone_a654+9sdf7+8we4f", "fakeone_aasd156465sfdef", zapLogger, 300)
+	var authenticate, _ = authentication.Authenticate(*authParams)
 	testConfig := ManagedAccountTestConfigStringResponse{
 		name: "TestManagedAccountCreateManagedAccountFlowEmptySystemList",
 		server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/api/secrets/secrets_test.go
+++ b/api/secrets/secrets_test.go
@@ -37,18 +37,38 @@ type SecretTestConfigStringResponse struct {
 // the default API version 3.0 will be used
 var apiVersion string = "3.1"
 
-func TestSecretGetSecretByPath(t *testing.T) {
+var authParams *authentication.AuthenticationParametersObj
+var zapLogger *logging.ZapLogger
+
+func InitializeGlobalConfig() {
+
 	logger, _ := zap.NewDevelopment()
 
-	// create a zap logger wrapper
-	zapLogger := logging.NewZapLogger(logger)
+	zapLogger = logging.NewZapLogger(logger)
 
 	httpClientObj, _ := utils.GetHttpClient(5, false, "", "", zapLogger)
 
 	backoffDefinition := backoff.NewExponentialBackOff()
 	backoffDefinition.MaxElapsedTime = time.Second
 
-	var authenticate, _ = authentication.Authenticate(*httpClientObj, backoffDefinition, "https://fake.api.com:443/BeyondTrust/api/public/v3/", apiVersion, "fakeone_a654+9sdf7+8we4f", "fakeone_aasd156465sfdef", zapLogger, 300)
+	authParams = &authentication.AuthenticationParametersObj{
+		HTTPClient:                 *httpClientObj,
+		BackoffDefinition:          backoffDefinition,
+		EndpointURL:                "https://fake.api.com:443/BeyondTrust/api/public/v3/",
+		APIVersion:                 apiVersion,
+		ClientID:                   "fakeone_a654+9sdf7+8we4f",
+		ClientSecret:               "fakeone_a654+9sdf7+8we4f",
+		ApiKey:                     "",
+		Logger:                     zapLogger,
+		RetryMaxElapsedTimeSeconds: 300,
+	}
+}
+
+func TestSecretGetSecretByPath(t *testing.T) {
+
+	InitializeGlobalConfig()
+
+	var authenticate, _ = authentication.Authenticate(*authParams)
 	testConfig := SecretTestConfig{
 		name: "TestSecretGetSecretByPath",
 		server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -80,16 +100,10 @@ func TestSecretGetSecretByPath(t *testing.T) {
 }
 
 func TestSecretGetFileSecret(t *testing.T) {
-	logger, _ := zap.NewDevelopment()
-	// create a zap logger wrapper
-	zapLogger := logging.NewZapLogger(logger)
 
-	httpClientObj, _ := utils.GetHttpClient(5, false, "", "", zapLogger)
+	InitializeGlobalConfig()
 
-	backoffDefinition := backoff.NewExponentialBackOff()
-	backoffDefinition.MaxElapsedTime = time.Second
-
-	var authenticate, _ = authentication.Authenticate(*httpClientObj, backoffDefinition, "https://fake.api.com:443/BeyondTrust/api/public/v3/", apiVersion, "fakeone_a654+9sdf7+8we4f", "fakeone_aasd156465sfdef", zapLogger, 300)
+	var authenticate, _ = authentication.Authenticate(*authParams)
 	testConfig := SecretTestConfig{
 		name: "TestSecretGetFileSecret",
 		server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -115,17 +129,10 @@ func TestSecretGetFileSecret(t *testing.T) {
 }
 
 func TestSecretFlow(t *testing.T) {
-	logger, _ := zap.NewDevelopment()
 
-	// create a zap logger wrapper
-	zapLogger := logging.NewZapLogger(logger)
+	InitializeGlobalConfig()
 
-	httpClientObj, _ := utils.GetHttpClient(5, false, "", "", zapLogger)
-
-	backoffDefinition := backoff.NewExponentialBackOff()
-	backoffDefinition.MaxElapsedTime = time.Second
-
-	var authenticate, _ = authentication.Authenticate(*httpClientObj, backoffDefinition, "https://fake.api.com:443/BeyondTrust/api/public/v3/", apiVersion, "fakeone_a654+9sdf7+8we4f", "fakeone_aasd156465sfdef", zapLogger, 300)
+	var authenticate, _ = authentication.Authenticate(*authParams)
 	testConfig := SecretTestConfigStringResponse{
 		name: "TestSecretFlow",
 		server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -179,17 +186,10 @@ func TestSecretFlow(t *testing.T) {
 }
 
 func TestSecretFlow_SecretNotFound(t *testing.T) {
-	logger, _ := zap.NewDevelopment()
 
-	// create a zap logger wrapper
-	zapLogger := logging.NewZapLogger(logger)
+	InitializeGlobalConfig()
 
-	httpClientObj, _ := utils.GetHttpClient(5, false, "", "", zapLogger)
-
-	backoffDefinition := backoff.NewExponentialBackOff()
-	backoffDefinition.MaxElapsedTime = time.Second
-
-	var authenticate, _ = authentication.Authenticate(*httpClientObj, backoffDefinition, "https://fake.api.com:443/BeyondTrust/api/public/v3/", apiVersion, "fakeone_a654+9sdf7+8we4f", "fakeone_aasd156465sfdef", zapLogger, 300)
+	var authenticate, _ = authentication.Authenticate(*authParams)
 	testConfig := SecretTestConfigStringResponse{
 		name: "TestSecretFlow_SecretNotFound",
 		server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -234,17 +234,10 @@ func TestSecretFlow_SecretNotFound(t *testing.T) {
 }
 
 func TestSecretGetSecret(t *testing.T) {
-	logger, _ := zap.NewDevelopment()
 
-	// create a zap logger wrapper
-	zapLogger := logging.NewZapLogger(logger)
+	InitializeGlobalConfig()
 
-	httpClientObj, _ := utils.GetHttpClient(5, false, "", "", zapLogger)
-
-	backoffDefinition := backoff.NewExponentialBackOff()
-	backoffDefinition.MaxElapsedTime = time.Second
-
-	var authenticate, _ = authentication.Authenticate(*httpClientObj, backoffDefinition, "https://fake.api.com:443/BeyondTrust/api/public/v3/", apiVersion, "fakeone_a654+9sdf7+8we4f", "fakeone_aasd156465sfdef", zapLogger, 300)
+	var authenticate, _ = authentication.Authenticate(*authParams)
 	testConfig := SecretTestConfigStringResponse{
 		name: "TestSecretGetSecret",
 		server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -273,17 +266,10 @@ func TestSecretGetSecret(t *testing.T) {
 }
 
 func TestSecretGetSecrets(t *testing.T) {
-	logger, _ := zap.NewDevelopment()
 
-	// create a zap logger wrapper
-	zapLogger := logging.NewZapLogger(logger)
+	InitializeGlobalConfig()
 
-	httpClientObj, _ := utils.GetHttpClient(5, false, "", "", zapLogger)
-
-	backoffDefinition := backoff.NewExponentialBackOff()
-	backoffDefinition.MaxElapsedTime = time.Second
-
-	var authenticate, _ = authentication.Authenticate(*httpClientObj, backoffDefinition, "https://fake.api.com:443/BeyondTrust/api/public/v3/", apiVersion, "fakeone_a654+9sdf7+8we4f", "fakeone_aasd156465sfdef", zapLogger, 300)
+	var authenticate, _ = authentication.Authenticate(*authParams)
 	testConfig := SecretTestConfigStringResponse{
 		name: "TestSecretGetSecrets",
 		server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -312,17 +298,10 @@ func TestSecretGetSecrets(t *testing.T) {
 }
 
 func TestSecretFlowTechnicalErrorFile(t *testing.T) {
-	logger, _ := zap.NewDevelopment()
 
-	// create a zap logger wrapper
-	zapLogger := logging.NewZapLogger(logger)
+	InitializeGlobalConfig()
 
-	httpClientObj, _ := utils.GetHttpClient(5, false, "", "", zapLogger)
-
-	backoffDefinition := backoff.NewExponentialBackOff()
-	backoffDefinition.MaxElapsedTime = time.Second
-
-	var authenticate, _ = authentication.Authenticate(*httpClientObj, backoffDefinition, "https://fake.api.com:443/BeyondTrust/api/public/v3/", apiVersion, "fakeone_a654+9sdf7+8we4f", "fakeone_aasd156465sfdef", zapLogger, 300)
+	var authenticate, _ = authentication.Authenticate(*authParams)
 	testConfig := SecretTestConfigStringResponse{
 		name: "TestSecretFlowTechnicalErrorFile",
 		server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -373,17 +352,10 @@ func TestSecretFlowTechnicalErrorFile(t *testing.T) {
 }
 
 func TestSecretFlowBusinessErrorFile(t *testing.T) {
-	logger, _ := zap.NewDevelopment()
 
-	// create a zap logger wrapper
-	zapLogger := logging.NewZapLogger(logger)
+	InitializeGlobalConfig()
 
-	httpClientObj, _ := utils.GetHttpClient(5, false, "", "", zapLogger)
-
-	backoffDefinition := backoff.NewExponentialBackOff()
-	backoffDefinition.MaxElapsedTime = time.Second
-
-	var authenticate, _ = authentication.Authenticate(*httpClientObj, backoffDefinition, "https://fake.api.com:443/BeyondTrust/api/public/v3/", apiVersion, "fakeone_a654+9sdf7+8we4f", "fakeone_aasd156465sfdef", zapLogger, 300)
+	var authenticate, _ = authentication.Authenticate(*authParams)
 	testConfig := SecretTestConfigStringResponse{
 		name: "TestSecretFlowBusinessErrorFile",
 		server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -434,17 +406,10 @@ func TestSecretFlowBusinessErrorFile(t *testing.T) {
 }
 
 func TestSecretFlowLongSecret(t *testing.T) {
-	logger, _ := zap.NewDevelopment()
 
-	// create a zap logger wrapper
-	zapLogger := logging.NewZapLogger(logger)
+	InitializeGlobalConfig()
 
-	httpClientObj, _ := utils.GetHttpClient(5, false, "", "", zapLogger)
-
-	backoffDefinition := backoff.NewExponentialBackOff()
-	backoffDefinition.MaxElapsedTime = time.Second
-
-	var authenticate, _ = authentication.Authenticate(*httpClientObj, backoffDefinition, "https://fake.api.com:443/BeyondTrust/api/public/v3/", apiVersion, "fakeone_a654+9sdf7+8we4f", "fakeone_aasd156465sfdef", zapLogger, 300)
+	var authenticate, _ = authentication.Authenticate(*authParams)
 	testConfig := SecretTestConfigStringResponse{
 		name: "TestSecretFlowLongSecret",
 		server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -496,17 +461,10 @@ func TestSecretFlowLongSecret(t *testing.T) {
 }
 
 func TestSecretFlowTechnicalErrorCredential(t *testing.T) {
-	logger, _ := zap.NewDevelopment()
 
-	// create a zap logger wrapper
-	zapLogger := logging.NewZapLogger(logger)
+	InitializeGlobalConfig()
 
-	httpClientObj, _ := utils.GetHttpClient(5, false, "", "", zapLogger)
-
-	backoffDefinition := backoff.NewExponentialBackOff()
-	backoffDefinition.MaxElapsedTime = time.Second
-
-	var authenticate, _ = authentication.Authenticate(*httpClientObj, backoffDefinition, "https://fake.api.com:443/BeyondTrust/api/public/v3/", apiVersion, "fakeone_a654+9sdf7+8we4f", "fakeone_aasd156465sfdef", zapLogger, 300)
+	var authenticate, _ = authentication.Authenticate(*authParams)
 	testConfig := SecretTestConfigStringResponse{
 		name: "TestSecretFlowTechnicalErrorCredential",
 		server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -551,17 +509,10 @@ func TestSecretFlowTechnicalErrorCredential(t *testing.T) {
 }
 
 func TestSecretFlowBusinessErrorCredential(t *testing.T) {
-	logger, _ := zap.NewDevelopment()
 
-	// create a zap logger wrapper
-	zapLogger := logging.NewZapLogger(logger)
+	InitializeGlobalConfig()
 
-	httpClientObj, _ := utils.GetHttpClient(5, false, "", "", zapLogger)
-
-	backoffDefinition := backoff.NewExponentialBackOff()
-	backoffDefinition.MaxElapsedTime = time.Second
-
-	var authenticate, _ = authentication.Authenticate(*httpClientObj, backoffDefinition, "https://fake.api.com:443/BeyondTrust/api/public/v3/", apiVersion, "fakeone_a654+9sdf7+8we4f", "fakeone_aasd156465sfdef", zapLogger, 300)
+	var authenticate, _ = authentication.Authenticate(*authParams)
 	testConfig := SecretTestConfigStringResponse{
 		name: "TestSecretFlowBusinessErrorCredential",
 		server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -606,17 +557,10 @@ func TestSecretFlowBusinessErrorCredential(t *testing.T) {
 }
 
 func TestSecretFlowBadBody(t *testing.T) {
-	logger, _ := zap.NewDevelopment()
 
-	// create a zap logger wrapper
-	zapLogger := logging.NewZapLogger(logger)
+	InitializeGlobalConfig()
 
-	httpClientObj, _ := utils.GetHttpClient(5, false, "", "", zapLogger)
-
-	backoffDefinition := backoff.NewExponentialBackOff()
-	backoffDefinition.MaxElapsedTime = time.Second
-
-	var authenticate, _ = authentication.Authenticate(*httpClientObj, backoffDefinition, "https://fake.api.com:443/BeyondTrust/api/public/v3/", apiVersion, "fakeone_a654+9sdf7+8we4f", "fakeone_aasd156465sfdef", zapLogger, 300)
+	var authenticate, _ = authentication.Authenticate(*authParams)
 	testConfig := SecretTestConfigStringResponse{
 		name: "TestSecretFlowBadBody",
 		server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -660,17 +604,10 @@ func TestSecretFlowBadBody(t *testing.T) {
 }
 
 func TestSecretCreateTextSecretFlow(t *testing.T) {
-	logger, _ := zap.NewDevelopment()
 
-	// create a zap logger wrapper
-	zapLogger := logging.NewZapLogger(logger)
+	InitializeGlobalConfig()
 
-	httpClientObj, _ := utils.GetHttpClient(5, false, "", "", zapLogger)
-
-	backoffDefinition := backoff.NewExponentialBackOff()
-	backoffDefinition.MaxElapsedTime = time.Second
-
-	var authenticate, _ = authentication.Authenticate(*httpClientObj, backoffDefinition, "https://fake.api.com:443/BeyondTrust/api/public/v3/", apiVersion, "fakeone_a654+9sdf7+8we4f", "fakeone_aasd156465sfdef", zapLogger, 300)
+	var authenticate, _ = authentication.Authenticate(*authParams)
 	testConfig := SecretTestConfigStringResponse{
 		name: "TestSecretCreateTextSecretFlow",
 		server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -732,17 +669,10 @@ func TestSecretCreateTextSecretFlow(t *testing.T) {
 }
 
 func TestSecretCreateCredentialSecretFlow(t *testing.T) {
-	logger, _ := zap.NewDevelopment()
 
-	// create a zap logger wrapper
-	zapLogger := logging.NewZapLogger(logger)
+	InitializeGlobalConfig()
 
-	httpClientObj, _ := utils.GetHttpClient(5, false, "", "", zapLogger)
-
-	backoffDefinition := backoff.NewExponentialBackOff()
-	backoffDefinition.MaxElapsedTime = time.Second
-
-	var authenticate, _ = authentication.Authenticate(*httpClientObj, backoffDefinition, "https://fake.api.com:443/BeyondTrust/api/public/v3/", apiVersion, "fakeone_a654+9sdf7+8we4f", "fakeone_aasd156465sfdef", zapLogger, 300)
+	var authenticate, _ = authentication.Authenticate(*authParams)
 	testConfig := SecretTestConfigStringResponse{
 		name: "TestSecretCreateCredentialSecretFlow",
 		server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -804,17 +734,10 @@ func TestSecretCreateCredentialSecretFlow(t *testing.T) {
 }
 
 func TestSecretCreateFileSecretFlow(t *testing.T) {
-	logger, _ := zap.NewDevelopment()
 
-	// create a zap logger wrapper
-	zapLogger := logging.NewZapLogger(logger)
+	InitializeGlobalConfig()
 
-	httpClientObj, _ := utils.GetHttpClient(5, false, "", "", zapLogger)
-
-	backoffDefinition := backoff.NewExponentialBackOff()
-	backoffDefinition.MaxElapsedTime = time.Second
-
-	var authenticate, _ = authentication.Authenticate(*httpClientObj, backoffDefinition, "https://fake.api.com:443/BeyondTrust/api/public/v3/", apiVersion, "fakeone_a654+9sdf7+8we4f", "fakeone_aasd156465sfdef", zapLogger, 300)
+	var authenticate, _ = authentication.Authenticate(*authParams)
 	testConfig := SecretTestConfigStringResponse{
 		name: "TestSecretCreateFileSecretFlow",
 		server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -876,17 +799,10 @@ func TestSecretCreateFileSecretFlow(t *testing.T) {
 }
 
 func TestSecretCreateFileSecretFlowError(t *testing.T) {
-	logger, _ := zap.NewDevelopment()
 
-	// create a zap logger wrapper
-	zapLogger := logging.NewZapLogger(logger)
+	InitializeGlobalConfig()
 
-	httpClientObj, _ := utils.GetHttpClient(5, false, "", "", zapLogger)
-
-	backoffDefinition := backoff.NewExponentialBackOff()
-	backoffDefinition.MaxElapsedTime = time.Second
-
-	var authenticate, _ = authentication.Authenticate(*httpClientObj, backoffDefinition, "https://fake.api.com:443/BeyondTrust/api/public/v3/", apiVersion, "fakeone_a654+9sdf7+8we4f", "fakeone_aasd156465sfdef", zapLogger, 300)
+	var authenticate, _ = authentication.Authenticate(*authParams)
 	testConfig := SecretTestConfigStringResponse{
 		name: "TestSecretCreateFileSecretFlowError",
 		server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -946,17 +862,10 @@ func TestSecretCreateFileSecretFlowError(t *testing.T) {
 }
 
 func TestSecretCreateBadInput(t *testing.T) {
-	logger, _ := zap.NewDevelopment()
 
-	// create a zap logger wrapper
-	zapLogger := logging.NewZapLogger(logger)
+	InitializeGlobalConfig()
 
-	httpClientObj, _ := utils.GetHttpClient(5, false, "", "", zapLogger)
-
-	backoffDefinition := backoff.NewExponentialBackOff()
-	backoffDefinition.MaxElapsedTime = time.Second
-
-	var authenticate, _ = authentication.Authenticate(*httpClientObj, backoffDefinition, "https://fake.api.com:443/BeyondTrust/api/public/v3/", apiVersion, "fakeone_a654+9sdf7+8we4f", "fakeone_aasd156465sfdef", zapLogger, 300)
+	var authenticate, _ = authentication.Authenticate(*authParams)
 	testConfig := SecretTestConfigStringResponse{
 		name: "TestSecretCreateBadInput",
 		server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -1011,17 +920,10 @@ func TestSecretCreateBadInput(t *testing.T) {
 }
 
 func TestSecretCreateSecretFlowFolderNotFound(t *testing.T) {
-	logger, _ := zap.NewDevelopment()
 
-	// create a zap logger wrapper
-	zapLogger := logging.NewZapLogger(logger)
+	InitializeGlobalConfig()
 
-	httpClientObj, _ := utils.GetHttpClient(5, false, "", "", zapLogger)
-
-	backoffDefinition := backoff.NewExponentialBackOff()
-	backoffDefinition.MaxElapsedTime = time.Second
-
-	var authenticate, _ = authentication.Authenticate(*httpClientObj, backoffDefinition, "https://fake.api.com:443/BeyondTrust/api/public/v3/", apiVersion, "fakeone_a654+9sdf7+8we4f", "fakeone_aasd156465sfdef", zapLogger, 300)
+	var authenticate, _ = authentication.Authenticate(*authParams)
 	testConfig := SecretTestConfigStringResponse{
 		name: "TestSecretCreateSecretFlowFolderNotFound",
 		server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -1070,17 +972,10 @@ func TestSecretCreateSecretFlowFolderNotFound(t *testing.T) {
 }
 
 func TestSecretCreateSecretFlowEmptyFolderList(t *testing.T) {
-	logger, _ := zap.NewDevelopment()
 
-	// create a zap logger wrapper
-	zapLogger := logging.NewZapLogger(logger)
+	InitializeGlobalConfig()
 
-	httpClientObj, _ := utils.GetHttpClient(5, false, "", "", zapLogger)
-
-	backoffDefinition := backoff.NewExponentialBackOff()
-	backoffDefinition.MaxElapsedTime = time.Second
-
-	var authenticate, _ = authentication.Authenticate(*httpClientObj, backoffDefinition, "https://fake.api.com:443/BeyondTrust/api/public/v3/", apiVersion, "fakeone_a654+9sdf7+8we4f", "fakeone_aasd156465sfdef", zapLogger, 300)
+	var authenticate, _ = authentication.Authenticate(*authParams)
 	testConfig := SecretTestConfigStringResponse{
 		name: "TestSecretCreateSecretFlowEmptyFolderList",
 		server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -1129,17 +1024,10 @@ func TestSecretCreateSecretFlowEmptyFolderList(t *testing.T) {
 }
 
 func TestSecretFolderFlow(t *testing.T) {
-	logger, _ := zap.NewDevelopment()
 
-	// create a zap logger wrapper
-	zapLogger := logging.NewZapLogger(logger)
+	InitializeGlobalConfig()
 
-	httpClientObj, _ := utils.GetHttpClient(5, false, "", "", zapLogger)
-
-	backoffDefinition := backoff.NewExponentialBackOff()
-	backoffDefinition.MaxElapsedTime = time.Second
-
-	var authenticate, _ = authentication.Authenticate(*httpClientObj, backoffDefinition, "https://fake.api.com:443/BeyondTrust/api/public/v3/", apiVersion, "fakeone_a654+9sdf7+8we4f", "fakeone_aasd156465sfdef", zapLogger, 300)
+	var authenticate, _ = authentication.Authenticate(*authParams)
 	testConfig := SecretTestConfigStringResponse{
 		name: "TestSecretFolderFlow",
 		server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -1186,17 +1074,10 @@ func TestSecretFolderFlow(t *testing.T) {
 }
 
 func TestSecretFolderFlowBadParentFolder(t *testing.T) {
-	logger, _ := zap.NewDevelopment()
 
-	// create a zap logger wrapper
-	zapLogger := logging.NewZapLogger(logger)
+	InitializeGlobalConfig()
 
-	httpClientObj, _ := utils.GetHttpClient(5, false, "", "", zapLogger)
-
-	backoffDefinition := backoff.NewExponentialBackOff()
-	backoffDefinition.MaxElapsedTime = time.Second
-
-	var authenticate, _ = authentication.Authenticate(*httpClientObj, backoffDefinition, "https://fake.api.com:443/BeyondTrust/api/public/v3/", apiVersion, "fakeone_a654+9sdf7+8we4f", "fakeone_aasd156465sfdef", zapLogger, 300)
+	var authenticate, _ = authentication.Authenticate(*authParams)
 	testConfig := SecretTestConfigStringResponse{
 		name: "TestSecretFolderFlowBadParentFolder",
 		server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -1243,17 +1124,10 @@ func TestSecretFolderFlowBadParentFolder(t *testing.T) {
 }
 
 func TestSecretFolderFlowEmptyParentFolder(t *testing.T) {
-	logger, _ := zap.NewDevelopment()
 
-	// create a zap logger wrapper
-	zapLogger := logging.NewZapLogger(logger)
+	InitializeGlobalConfig()
 
-	httpClientObj, _ := utils.GetHttpClient(5, false, "", "", zapLogger)
-
-	backoffDefinition := backoff.NewExponentialBackOff()
-	backoffDefinition.MaxElapsedTime = time.Second
-
-	var authenticate, _ = authentication.Authenticate(*httpClientObj, backoffDefinition, "https://fake.api.com:443/BeyondTrust/api/public/v3/", apiVersion, "fakeone_a654+9sdf7+8we4f", "fakeone_aasd156465sfdef", zapLogger, 300)
+	var authenticate, _ = authentication.Authenticate(*authParams)
 
 	secretObj, _ := NewSecretObj(*authenticate, zapLogger, 4000)
 
@@ -1276,17 +1150,10 @@ func TestSecretFolderFlowEmptyParentFolder(t *testing.T) {
 }
 
 func TestSecretSafeFlow(t *testing.T) {
-	logger, _ := zap.NewDevelopment()
 
-	// create a zap logger wrapper
-	zapLogger := logging.NewZapLogger(logger)
+	InitializeGlobalConfig()
 
-	httpClientObj, _ := utils.GetHttpClient(5, false, "", "", zapLogger)
-
-	backoffDefinition := backoff.NewExponentialBackOff()
-	backoffDefinition.MaxElapsedTime = time.Second
-
-	var authenticate, _ = authentication.Authenticate(*httpClientObj, backoffDefinition, "https://fake.api.com:443/BeyondTrust/api/public/v3/", apiVersion, "fakeone_a654+9sdf7+8we4f", "fakeone_aasd156465sfdef", zapLogger, 300)
+	var authenticate, _ = authentication.Authenticate(*authParams)
 	testConfig := SecretTestConfigStringResponse{
 		name: "TestSecretSafeFlow",
 		server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/api/utils/validator.go
+++ b/api/utils/validator.go
@@ -36,7 +36,7 @@ type UserInputValidaton struct {
 	ApiKey                 string `validate:"omitempty,min=128,max=263"`
 	ClientId               string `validate:"omitempty,min=36,max=36,required_without=ApiKey"`
 	ClientSecret           string `validate:"omitempty,min=36,max=64,required_without=ApiKey"`
-	ApiVersion             string `validate:"omitempty,min=3,max=10"`
+	ApiVersion             string `validate:"omitempty,min=3,max=3"`
 	ApiUrl                 string `validate:"required,http_url"`
 	ClientTimeOutinSeconds int    `validate:"gte=1,lte=300"`
 	Separator              string `validate:"required,min=1,max=1"`

--- a/api/utils/validator.go
+++ b/api/utils/validator.go
@@ -20,6 +20,7 @@ type ValidationParams struct {
 	ClientID                   string
 	ClientSecret               string
 	ApiUrl                     *string
+	ApiVersion                 string
 	ClientTimeOutInSeconds     int
 	Separator                  *string
 	VerifyCa                   bool
@@ -35,6 +36,7 @@ type UserInputValidaton struct {
 	ApiKey                 string `validate:"omitempty,min=128,max=263"`
 	ClientId               string `validate:"omitempty,min=36,max=36,required_without=ApiKey"`
 	ClientSecret           string `validate:"omitempty,min=36,max=64,required_without=ApiKey"`
+	ApiVersion             string `validate:"omitempty,min=3,max=10"`
 	ApiUrl                 string `validate:"required,http_url"`
 	ClientTimeOutinSeconds int    `validate:"gte=1,lte=300"`
 	Separator              string `validate:"required,min=1,max=1"`
@@ -77,6 +79,7 @@ func ValidateInputs(params ValidationParams) error {
 		ClientId:               params.ClientID,
 		ClientSecret:           params.ClientSecret,
 		ApiUrl:                 *params.ApiUrl,
+		ApiVersion:             params.ApiVersion,
 		ClientTimeOutinSeconds: params.ClientTimeOutInSeconds,
 		Separator:              *params.Separator,
 		MaxFileSecretSizeBytes: *params.MaxFileSecretSizeBytes,


### PR DESCRIPTION
### Purpose of the PR
Include API version parameter in integrations

### According to ticket
[BIPS-24104](https://beyondtrust.atlassian.net/browse/BIPS-24104)

### Summary of changes:
- Unify authenticate method parameters in just one object
- Fix unit tests after above change
- Include validation for API version parameter

[BIPS-24104]: https://beyondtrust.atlassian.net/browse/BIPS-24104?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ