### PR TITLE
fix: improve authenticate method call parameters in fuzzing test

### DIFF
--- a/fuzzing/managed_accounts/get_managed_accounts_fuzz_test.go
+++ b/fuzzing/managed_accounts/get_managed_accounts_fuzz_test.go
@@ -22,6 +22,10 @@ type TestConfig struct {
 	response string
 }
 
+// the recommended version is 3.1. If no version is specified,
+// the default API version 3.0 will be used
+var apiVersion string = "3.1"
+
 func FuzzGetManagedAccount(f *testing.F) {
 
 	testConfig := TestConfig{
@@ -83,8 +87,20 @@ func FuzzGetManagedAccount(f *testing.F) {
 	backoffDefinition := backoff.NewExponentialBackOff()
 	backoffDefinition.MaxElapsedTime = time.Second
 
+	authParamsOauth := &authentication.AuthenticationParametersObj{
+		HTTPClient:                 *httpClientObj,
+		BackoffDefinition:          backoffDefinition,
+		EndpointURL:                "https://fake.api.com:443/BeyondTrust/api/public/v3/",
+		APIVersion:                 apiVersion,
+		ClientID:                   "fakeone_a654+9sdf7+8we4f",
+		ClientSecret:               "fakeone_a654+9sdf7+8we4f",
+		ApiKey:                     "",
+		Logger:                     zapLogger,
+		RetryMaxElapsedTimeSeconds: 300,
+	}
+
 	// instantiating authenticate obj, injecting httpClient object
-	var authenticate, _ = authentication.Authenticate(*httpClientObj, backoffDefinition, "https://fake.api.com:443/BeyondTrust/api/public/v3/", "fakeone_a654+9sdf7+8we4f", "fakeone_aasd156465sfdef", zapLogger, 300)
+	var authenticate, _ = authentication.Authenticate(*authParamsOauth)
 
 	apiUrl, _ := url.Parse(testConfig.server.URL + "/")
 	authenticate.ApiUrl = *apiUrl

--- a/fuzzing/secrets/get_secrets_fuzz_test.go
+++ b/fuzzing/secrets/get_secrets_fuzz_test.go
@@ -23,6 +23,10 @@ type TestConfig struct {
 	response string
 }
 
+// the recommended version is 3.1. If no version is specified,
+// the default API version 3.0 will be used
+var apiVersion string = "3.1"
+
 func FuzzGetSecret(f *testing.F) {
 
 	testConfig := TestConfig{
@@ -72,8 +76,20 @@ func FuzzGetSecret(f *testing.F) {
 	backoffDefinition := backoff.NewExponentialBackOff()
 	backoffDefinition.MaxElapsedTime = time.Second
 
+	authParamsOauth := &authentication.AuthenticationParametersObj{
+		HTTPClient:                 *httpClientObj,
+		BackoffDefinition:          backoffDefinition,
+		EndpointURL:                "https://fake.api.com:443/BeyondTrust/api/public/v3/",
+		APIVersion:                 apiVersion,
+		ClientID:                   "fakeone_a654+9sdf7+8we4f",
+		ClientSecret:               "fakeone_a654+9sdf7+8we4f",
+		ApiKey:                     "",
+		Logger:                     zapLogger,
+		RetryMaxElapsedTimeSeconds: 300,
+	}
+
 	// instantiating authenticate obj, injecting httpClient object
-	var authenticate, _ = authentication.Authenticate(*httpClientObj, backoffDefinition, "https://fake.api.com:443/BeyondTrust/api/public/v3/", "fakeone_a654+9sdf7+8we4f", "fakeone_aasd156465sfdef", zapLogger, 300)
+	var authenticate, _ = authentication.Authenticate(*authParamsOauth)
 
 	apiUrl, _ := url.Parse(testConfig.server.URL + "/")
 	authenticate.ApiUrl = *apiUrl


### PR DESCRIPTION
### Purpose of the PR
Improve authenticate method call parameters in fuzzing test

### According to ticket
[BIPS-24390](https://beyondtrust.atlassian.net/browse/BIPS-24390)

### Summary of changes:
change authenticate method call parameters in fuzzing tests to send an object with all parameters with in. 


[BIPS-24390]: https://beyondtrust.atlassian.net/browse/BIPS-24390?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ