### PR TITLE
fix: plugin crashed - with nonexistent API server

### DIFF
--- a/TestClient.go
+++ b/TestClient.go
@@ -8,6 +8,7 @@ import (
 	"github.com/BeyondTrust/go-client-library-passwordsafe/api/authentication"
 	"github.com/BeyondTrust/go-client-library-passwordsafe/api/entities"
 	logging "github.com/BeyondTrust/go-client-library-passwordsafe/api/logging"
+	managed_accounts "github.com/BeyondTrust/go-client-library-passwordsafe/api/managed_account"
 	"github.com/BeyondTrust/go-client-library-passwordsafe/api/secrets"
 	"github.com/BeyondTrust/go-client-library-passwordsafe/api/utils"
 	"github.com/google/uuid"

--- a/TestClient.go
+++ b/TestClient.go
@@ -2,12 +2,12 @@ package main
 
 import (
 	"fmt"
+	"os"
 	"time"
 
 	"github.com/BeyondTrust/go-client-library-passwordsafe/api/authentication"
 	"github.com/BeyondTrust/go-client-library-passwordsafe/api/entities"
 	logging "github.com/BeyondTrust/go-client-library-passwordsafe/api/logging"
-	managed_accounts "github.com/BeyondTrust/go-client-library-passwordsafe/api/managed_account"
 	"github.com/BeyondTrust/go-client-library-passwordsafe/api/secrets"
 	"github.com/BeyondTrust/go-client-library-passwordsafe/api/utils"
 	"github.com/google/uuid"
@@ -244,6 +244,13 @@ func main() {
 	// WARNING: Do not log secrets in production code, the following log statement logs test secrets for testing purposes:
 	zapLogger.Debug(fmt.Sprintf("Created Text secret: %v", createdSecret.Title))
 
+	// just for test purposes, file test_secret.txt should not be present in repo.
+	fileContent, err := os.ReadFile("test_secret.txt")
+	if err != nil {
+		fmt.Println("Error reading file:", err)
+		return
+	}
+
 	objFile := entities.SecretFileDetails{
 		Title:       "FILE_" + uuid.New().String(),
 		Description: "My File Secret Description",
@@ -259,7 +266,7 @@ func main() {
 		},
 		Notes:       "Notes 1",
 		FileName:    "my_secret.txt",
-		FileContent: "my_p4ssword!*2024",
+		FileContent: string(fileContent),
 		Urls: []entities.UrlDetails{
 			{
 				Id:           uuid.New(),

--- a/api/authentication/authentication_test.go
+++ b/api/authentication/authentication_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"reflect"
+	"strings"
 	"testing"
 	"time"
 
@@ -144,16 +145,13 @@ func TestSignAppinWithWrongAPIURL(t *testing.T) {
 	InitializeGlobalConfig()
 
 	var authenticate, _ = Authenticate(*authParamsOauth)
-	testConfig := UserTestConfig{
-		name:     "TestSignAppinWithWrongAPIURL",
-		server:   httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})),
-		response: &entities.SignApinResponse{},
-	}
 
-	_, err := authenticate.SignAppin("https://fakeUrl.com/BeyondTrust/"+"TestSignAppin", "", "")
+	_, err := authenticate.SignAppin("https://fakeurl.com/BeyondTrust/"+"TestSignAppin", "", "")
 
-	if err.Error() != `Post "https://fakeUrl.com/BeyondTrust/TestSignAppin": dial tcp: lookup fakeUrl.com on 8.8.8.8:53: no such host` {
-		t.Errorf("Test case Failed %v, %v", err.Error(), testConfig.response)
+	expectedResponse := `Post "https://fakeurl.com/BeyondTrust/TestSignAppin": dial tcp: lookup fakeurl.com`
+
+	if !strings.Contains(err.Error(), expectedResponse) {
+		t.Errorf("Test case Failed %v, %v", err.Error(), expectedResponse)
 	}
 }
 

--- a/api/authentication/authentication_test.go
+++ b/api/authentication/authentication_test.go
@@ -139,6 +139,24 @@ func TestSignAppin(t *testing.T) {
 	}
 }
 
+func TestSignAppinWithWrongAPIURL(t *testing.T) {
+
+	InitializeGlobalConfig()
+
+	var authenticate, _ = Authenticate(*authParamsOauth)
+	testConfig := UserTestConfig{
+		name:     "TestSignAppinWithWrongAPIURL",
+		server:   httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})),
+		response: &entities.SignApinResponse{},
+	}
+
+	_, err := authenticate.SignAppin("https://fakeUrl.com/BeyondTrust/"+"TestSignAppin", "", "")
+
+	if err.Error() != `Post "https://fakeUrl.com/BeyondTrust/TestSignAppin": dial tcp: lookup fakeUrl.com on 8.8.8.8:53: no such host` {
+		t.Errorf("Test case Failed %v, %v", err.Error(), testConfig.response)
+	}
+}
+
 func TestSignAppinWithApiKey(t *testing.T) {
 
 	InitializeGlobalConfig()

--- a/api/entities/entities.go
+++ b/api/entities/entities.go
@@ -133,7 +133,7 @@ type SecretFileDetails struct {
 	Owners      []OwnerDetails `json:",omitempty" validate:"required_if=OwnerType User"`
 	Notes       string         `json:",omitempty" validate:"omitempty,max=4000"`
 	FileName    string         `json:",omitempty" validate:"required,max=256"`
-	FileContent string         `json:",omitempty" validate:"required,max=256"`
+	FileContent string         `json:",omitempty" validate:"required,max=5000000"`
 	Urls        []UrlDetails   `json:",omitempty" validate:"omitempty"`
 }
 

--- a/api/utils/httpclient.go
+++ b/api/utils/httpclient.go
@@ -149,8 +149,11 @@ func (client *HttpClientObj) HttpRequest(url string, method string, body bytes.B
 
 	resp, err := client.HttpClient.Do(req)
 	if err != nil {
-		client.log.Error(fmt.Sprintf("%v %v", "Error Making request: ", err.Error()))
-		return nil, resp.StatusCode, err, nil
+		client.log.Debug(fmt.Sprintf("%v %v", "Error Making request: ", err.Error()))
+		if resp != nil {
+			return nil, resp.StatusCode, err, nil
+		}
+		return nil, 0, err, nil
 	}
 
 	if resp.StatusCode >= http.StatusInternalServerError || resp.StatusCode == http.StatusRequestTimeout {


### PR DESCRIPTION
### Purpose of the PR
Fix plugin crashed - with nonexistent API server

### According to ticket
<!-- Jira url or ticket number -->
https://beyondtrust.atlassian.net/browse/BIPS-24883

### Summary of changes:
Include validation to avoid nil pointer error in httpclient.go file
Change max file size to 5MB in create file secret flow.
Add unit tests to the completed fixes.
