### PR TITLE
CI: [BIPS-25959] New path for artifacts added & Frogbot fixed

### DIFF
--- a/.github/workflows/frogbot.yml
+++ b/.github/workflows/frogbot.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
-      contents: read
+      contents: write
       id-token: write
     steps:
       - name: Checkout

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -170,17 +170,17 @@ jobs:
 
       - name: Setting up artifactory
         run: |
-          mkdir -p go-library-passwordsafe/${{ needs.build.outputs.full_version }}
+          mkdir -p passwordsafe/go-library-passwordsafe/${{ needs.build.outputs.full_version }}
 
       - name: Download library binary
         uses: actions/download-artifact@cc203385981b70ca67e1cc392babf9cc229d5806 # v4.1.9
         with:
           name: library
-          path: go-library-passwordsafe/${{ needs.build.outputs.full_version }}
+          path: passwordsafe/go-library-passwordsafe/${{ needs.build.outputs.full_version }}
 
       - name: Send artifacts to Jfrog
         run: |
-          jfrog rt u "go-library-passwordsafe/${{ needs.build.outputs.full_version }}/*" ${{ env.JFROG_SERVER }}
+          jfrog rt u "passwordsafe/go-library-passwordsafe/${{ needs.build.outputs.full_version }}/*" ${{ env.JFROG_SERVER }}
 
       - name: Publish Build Information
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -170,17 +170,17 @@ jobs:
 
       - name: Setting up artifactory
         run: |
-          mkdir -p passwordsafe/go-library-passwordsafe/${{ needs.build.outputs.full_version }}
+          mkdir -p beyondtrust/passwordsafe/go-library-passwordsafe/${{ needs.build.outputs.full_version }}
 
       - name: Download library binary
         uses: actions/download-artifact@cc203385981b70ca67e1cc392babf9cc229d5806 # v4.1.9
         with:
           name: library
-          path: passwordsafe/go-library-passwordsafe/${{ needs.build.outputs.full_version }}
+          path: beyondtrust/passwordsafe/go-library-passwordsafe/${{ needs.build.outputs.full_version }}
 
       - name: Send artifacts to Jfrog
         run: |
-          jfrog rt u "passwordsafe/go-library-passwordsafe/${{ needs.build.outputs.full_version }}/*" ${{ env.JFROG_SERVER }}
+          jfrog rt u "beyondtrust/passwordsafe/go-library-passwordsafe/${{ needs.build.outputs.full_version }}/*" ${{ env.JFROG_SERVER }}
 
       - name: Publish Build Information
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,7 @@ name: Release
 
 env:
   JFROG_CLI_BUILD_NAME: ${{ github.event.repository.name }}
-  JFROG_SERVER: eng-generic-dev-local
+  JFROG_SERVER: eng-go-dev-local
   SONAR_TOKEN: ${{ secrets.SONARQUBE_TOKEN }}
 
 on:


### PR DESCRIPTION
### Purpose of the PR
Update go-library-passordsafe build artifact path of Jfrog server

### According to ticket
[BIPS-25959](https://beyondtrust.atlassian.net/browse/BIPS-25959)

### Summary of changes:
<!-- Fill in the summary of changes -->
- New path added for artifact to upload them into Jfrog server
- Frogbot fixed, unable to create PRs

[BIPS-25959]: https://beyondtrust.atlassian.net/browse/BIPS-25959?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ