### PR TITLE
ci: update oidc provider name

### DIFF
--- a/.github/workflows/frogbot.yml
+++ b/.github/workflows/frogbot.yml
@@ -30,7 +30,7 @@ jobs:
         env:
           JF_URL: https://beyondtrust.jfrog.io
         with:
-          oidc-provider-name: go-client-library-passwordsafe
+          oidc-provider-name: nonprod-go-client-library-passwordsafe
 
       - name: Run XRay scan
         uses: jfrog/frogbot@7fad842cf6ba3d755c2eb86376cce066327b55d1 # v2.25.0
@@ -38,4 +38,4 @@ jobs:
           JF_URL: https://beyondtrust.jfrog.io
           JF_GIT_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          oidc-provider-name: go-client-library-passwordsafe
+          oidc-provider-name: nonprod-go-client-library-passwordsafe

--- a/.github/workflows/promotion.yml
+++ b/.github/workflows/promotion.yml
@@ -18,7 +18,7 @@ jobs:
         env:
           JF_URL: https://beyondtrust.jfrog.io
         with:
-          oidc-provider-name: go-client-library-passwordsafe
+          oidc-provider-name: prod-go-client-library-passwordsafe
 
       - name: Extract version
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -162,7 +162,7 @@ jobs:
         env:
           JF_URL: https://beyondtrust.jfrog.io
         with:
-          oidc-provider-name: go-client-library-passwordsafe
+          oidc-provider-name: nonprod-go-client-library-passwordsafe
 
       - name: Configure JFrog CLI build number
         run: |


### PR DESCRIPTION
### Purpose of the PR
Fix the OIDC integration

### According to ticket
DX-2157

### Summary of changes:
Access has been split into prod (for promotion) and nonprod (for CI). This PR updates the workflows with the new OIDC names.
