### PR TITLE
feat: add support for API version (3.0, 3.1) in create credential, text and file features

### DIFF
--- a/TestClient.go
+++ b/TestClient.go
@@ -123,7 +123,7 @@ func main() {
 	certificateName := os.Getenv("PASSWORD_SAFE_CERTIFICATE_NAME")
 	certificatePassword := os.Getenv("PASSWORD_SAFE_CERTIFICATE_PASSWORD")
 
-	clientTimeOutInSeconds := 30
+	clientTimeOutInSeconds := 300
 	verifyCa := true
 	retryMaxElapsedTimeMinutes := 2
 
@@ -436,15 +436,13 @@ func CreateSecretsAndFolders(authenticationObj *authentication.AuthenticationObj
 		},
 	}
 
-	objFile := entities.SecretFileDetailsConfig30{
+	objFile := entities.SecretFileDetailsConfig31{
 		SecretDetailsBaseConfig: secretDetailsConfig,
-		OwnerType:               "User",
-		OwnerId:                 userObject.UserId,
-		Owners: []entities.OwnerDetailsOwnerId{
+		Owners: []entities.OwnerDetailsGroupId{
 			{
-				OwnerId: userObject.UserId,
-				Owner:   userObject.UserName,
-				Email:   userObject.EmailAddress,
+				UserId: userObject.UserId,
+				Name:   userObject.UserName,
+				Email:  userObject.EmailAddress,
 			},
 		},
 

--- a/TestClient.go
+++ b/TestClient.go
@@ -212,6 +212,12 @@ func main() {
 		return
 	}
 
+	err = CreateManagedSystem(authenticate, zapLogger)
+	if err != nil {
+		zapLogger.Error(err.Error())
+		return
+	}
+
 	// signing out
 	err = authenticate.SignOut()
 
@@ -336,26 +342,31 @@ func CreateManagedAccount(authenticationObj *authentication.AuthenticationObj, z
 func CreateSecretsAndFolders(authenticationObj *authentication.AuthenticationObj, zapLogger *logging.ZapLogger, userObject entities.SignAppinResponse, maxFileSecretSizeBytes int) error {
 
 	secretObj, _ := secrets.NewSecretObj(*authenticationObj, zapLogger, maxFileSecretSizeBytes)
-	objCredential := entities.SecretCredentialDetails{
+
+	secretDetailsConfig := entities.SecretDetailsBaseConfig{
 		Title:       "CREDENTIAL_" + identifier,
 		Description: "My Credential Secret Description",
-		Username:    "my_user",
-		Password:    constants.FakePassword,
-		OwnerType:   "User",
 		Notes:       "My note",
-		Owners: []entities.OwnerDetails{
-			{
-				GroupId: 1,
-				OwnerId: userObject.UserId,
-				Owner:   userObject.UserName,
-				Email:   userObject.EmailAddress,
-			},
-		},
 		Urls: []entities.UrlDetails{
 			{
 				Id:           uuid.New(),
 				CredentialId: uuid.New(),
 				Url:          "https://www.test.com/",
+			},
+		},
+	}
+
+	objCredential := entities.SecretCredentialDetailsConfig31{
+		SecretDetailsBaseConfig: secretDetailsConfig,
+		Username:                "my_user",
+		Password:                constants.FakePassword,
+
+		Owners: []entities.OwnerDetailsGroupId{
+			{
+				GroupId: 1,
+				UserId:  userObject.UserId,
+				Name:    userObject.UserName,
+				Email:   userObject.EmailAddress,
 			},
 		},
 	}
@@ -370,26 +381,27 @@ func CreateSecretsAndFolders(authenticationObj *authentication.AuthenticationObj
 	// WARNING: Do not log secrets in production code, the following log statement logs test secrets for testing purposes:
 	zapLogger.Debug(fmt.Sprintf("Created Credential secret: %v", createdSecret.Title))
 
-	objText := entities.SecretTextDetails{
+	secretDetailsConfig = entities.SecretDetailsBaseConfig{
 		Title:       "TEXT_" + identifier,
 		Description: "My Text Secret Description",
-		Text:        constants.FakePassword,
-		OwnerType:   "User",
-		OwnerId:     userObject.UserId,
-		FolderId:    uuid.New(),
-		Owners: []entities.OwnerDetails{
-			{
-				GroupId: 1,
-				OwnerId: userObject.UserId,
-				Owner:   userObject.UserName,
-				Email:   userObject.EmailAddress,
-			},
-		},
 		Urls: []entities.UrlDetails{
 			{
 				Id:           uuid.New(),
 				CredentialId: uuid.New(),
 				Url:          "https://www.test.com/",
+			},
+		},
+	}
+
+	objText := entities.SecretTextDetailsConfig31{
+		SecretDetailsBaseConfig: secretDetailsConfig,
+		Text:                    constants.FakePassword,
+		FolderId:                uuid.New(),
+		Owners: []entities.OwnerDetailsGroupId{
+			{
+				UserId: userObject.UserId,
+				Name:   userObject.UserName,
+				Email:  userObject.EmailAddress,
 			},
 		},
 	}
@@ -411,22 +423,10 @@ func CreateSecretsAndFolders(authenticationObj *authentication.AuthenticationObj
 		return nil
 	}
 
-	objFile := entities.SecretFileDetails{
+	secretDetailsConfig = entities.SecretDetailsBaseConfig{
 		Title:       "FILE_" + identifier,
 		Description: "My File Secret Description",
-		OwnerType:   "User",
-		OwnerId:     userObject.UserId,
-		Owners: []entities.OwnerDetails{
-			{
-				GroupId: 1,
-				OwnerId: userObject.UserId,
-				Owner:   userObject.UserName,
-				Email:   userObject.EmailAddress,
-			},
-		},
 		Notes:       "Notes 1",
-		FileName:    "my_secret.txt",
-		FileContent: string(fileContent),
 		Urls: []entities.UrlDetails{
 			{
 				Id:           uuid.New(),
@@ -434,6 +434,22 @@ func CreateSecretsAndFolders(authenticationObj *authentication.AuthenticationObj
 				Url:          "https://www.test.com/",
 			},
 		},
+	}
+
+	objFile := entities.SecretFileDetailsConfig30{
+		SecretDetailsBaseConfig: secretDetailsConfig,
+		OwnerType:               "User",
+		OwnerId:                 userObject.UserId,
+		Owners: []entities.OwnerDetailsOwnerId{
+			{
+				OwnerId: userObject.UserId,
+				Owner:   userObject.UserName,
+				Email:   userObject.EmailAddress,
+			},
+		},
+
+		FileName:    "my_secret.txt",
+		FileContent: string(fileContent),
 	}
 
 	// creating a file secret in folder1.

--- a/TestClient.go
+++ b/TestClient.go
@@ -123,7 +123,7 @@ func main() {
 	certificateName := os.Getenv("PASSWORD_SAFE_CERTIFICATE_NAME")
 	certificatePassword := os.Getenv("PASSWORD_SAFE_CERTIFICATE_PASSWORD")
 
-	clientTimeOutInSeconds := 300
+	clientTimeOutInSeconds := 30
 	verifyCa := true
 	retryMaxElapsedTimeMinutes := 2
 

--- a/api/entities/entities.go
+++ b/api/entities/entities.go
@@ -119,19 +119,6 @@ type CreateSecretResponse struct {
 	FolderId    string
 }
 
-type SecretCredentialDetails struct {
-	Title          string         `json:",omitempty" validate:"required"`
-	Description    string         `json:",omitempty" validate:"omitempty,max=256"`
-	Username       string         `json:",omitempty" validate:"required"`
-	Password       string         `json:",omitempty" validate:"max=256,required_without=PasswordRuleID"`
-	OwnerId        int            `json:",omitempty" validate:"required_if=OwnerType Group"`
-	OwnerType      string         `json:",omitempty" validate:"required,oneof=User Group"`
-	Owners         []OwnerDetails `json:",omitempty" validate:"required_if=OwnerType User"`
-	Notes          string         `json:",omitempty" validate:"omitempty,max=4000"`
-	Urls           []UrlDetails   `json:",omitempty" validate:"omitempty"`
-	PasswordRuleID int            `json:",omitempty" validate:"omitempty"`
-}
-
 type SecretCredentialDetailsConfig30 struct {
 	SecretDetailsBaseConfig
 	Username       string                `json:",omitempty" validate:"required"`
@@ -148,18 +135,6 @@ type SecretCredentialDetailsConfig31 struct {
 	Password       string                `json:",omitempty" validate:"max=256,required_without=PasswordRuleID"`
 	Owners         []OwnerDetailsGroupId `json:",omitempty" validate:"required_if=OwnerType User"`
 	PasswordRuleID int                   `json:",omitempty" validate:"omitempty"`
-}
-
-type SecretTextDetails struct {
-	Title       string         `json:",omitempty" validate:"required,max=256"`
-	Description string         `json:",omitempty" validate:"omitempty,max=256"`
-	Text        string         `json:",omitempty" validate:"required,max=4096"`
-	OwnerId     int            `json:",omitempty" validate:"required_if=OwnerType Group"`
-	OwnerType   string         `json:",omitempty" validate:"required,oneof=User Group"`
-	Owners      []OwnerDetails `json:",omitempty" validate:"required_if=OwnerType User"`
-	Notes       string         `json:",omitempty" validate:"omitempty,max=4000"`
-	FolderId    uuid.UUID      `json:",omitempty" validate:"omitempty"`
-	Urls        []UrlDetails   `json:",omitempty" validate:"omitempty"`
 }
 
 type SecretDetailsBaseConfig struct {
@@ -185,18 +160,6 @@ type SecretTextDetailsConfig31 struct {
 	FolderId uuid.UUID             `json:",omitempty" validate:"omitempty"`
 }
 
-type SecretFileDetails struct {
-	Title       string         `json:",omitempty" validate:"required,max=256"`
-	Description string         `json:",omitempty" validate:"omitempty,max=256"`
-	OwnerId     int            `json:",omitempty" validate:"required_if=OwnerType Group"`
-	OwnerType   string         `json:",omitempty" validate:"required,oneof=User Group"`
-	Owners      []OwnerDetails `json:",omitempty" validate:"required_if=OwnerType User"`
-	Notes       string         `json:",omitempty" validate:"omitempty,max=4000"`
-	FileName    string         `json:",omitempty" validate:"required,max=256"`
-	FileContent string         `json:",omitempty" validate:"required,max=5000000"`
-	Urls        []UrlDetails   `json:",omitempty" validate:"omitempty"`
-}
-
 type SecretFileDetailsConfig30 struct {
 	SecretDetailsBaseConfig
 	OwnerId     int                   `json:",omitempty" validate:"required_if=OwnerType Group"`
@@ -210,14 +173,8 @@ type SecretFileDetailsConfig31 struct {
 	SecretDetailsBaseConfig
 	Owners      []OwnerDetailsGroupId `json:",omitempty" validate:"required_if=OwnerType User"`
 	FileName    string                `json:",omitempty" validate:"required,max=256"`
+	OwnerType   string                `json:",omitempty" validate:"required,oneof=User Group"`
 	FileContent string                `json:",omitempty" validate:"required,max=5000000"`
-}
-
-type OwnerDetails struct {
-	GroupId int    `json:",omitempty" validate:"required,min=1,max=2147483647"`
-	OwnerId int    `json:",omitempty" validate:"required,min=1,max=2147483647"`
-	Owner   string `json:",omitempty" validate:"omitempty"`
-	Email   string `json:",omitempty" validate:"omitempty"`
 }
 
 type OwnerDetailsOwnerId struct {

--- a/api/entities/entities.go
+++ b/api/entities/entities.go
@@ -133,7 +133,7 @@ type SecretCredentialDetailsConfig31 struct {
 	SecretDetailsBaseConfig
 	Username       string                `json:",omitempty" validate:"required"`
 	Password       string                `json:",omitempty" validate:"max=256,required_without=PasswordRuleID"`
-	Owners         []OwnerDetailsGroupId `json:",omitempty" validate:"required_if=OwnerType User"`
+	Owners         []OwnerDetailsGroupId `json:",omitempty" validate:"required"`
 	PasswordRuleID int                   `json:",omitempty" validate:"omitempty"`
 }
 
@@ -148,7 +148,7 @@ type SecretTextDetailsConfig30 struct {
 	SecretDetailsBaseConfig
 	Text      string                `json:",omitempty" validate:"required,max=4096"`
 	OwnerId   int                   `json:",omitempty" validate:"required_if=OwnerType Group"`
-	OwnerType string                `json:",omitempty" validate:"required,oneof=User Group"`
+	OwnerType string                `json:",omitempty" validate:"oneof=User Group"`
 	Owners    []OwnerDetailsOwnerId `json:",omitempty" validate:"required_if=OwnerType User"`
 	FolderId  uuid.UUID             `json:",omitempty" validate:"omitempty"`
 }
@@ -156,14 +156,14 @@ type SecretTextDetailsConfig30 struct {
 type SecretTextDetailsConfig31 struct {
 	SecretDetailsBaseConfig
 	Text     string                `json:",omitempty" validate:"required,max=4096"`
-	Owners   []OwnerDetailsGroupId `json:",omitempty" validate:"required_if=OwnerType User"`
+	Owners   []OwnerDetailsGroupId `json:",omitempty" validate:"required"`
 	FolderId uuid.UUID             `json:",omitempty" validate:"omitempty"`
 }
 
 type SecretFileDetailsConfig30 struct {
 	SecretDetailsBaseConfig
 	OwnerId     int                   `json:",omitempty" validate:"required_if=OwnerType Group"`
-	OwnerType   string                `json:",omitempty" validate:"required,oneof=User Group"`
+	OwnerType   string                `json:",omitempty" validate:"oneof=User Group"`
 	Owners      []OwnerDetailsOwnerId `json:",omitempty" validate:"required_if=OwnerType User"`
 	FileName    string                `json:",omitempty" validate:"required,max=256"`
 	FileContent string                `json:",omitempty" validate:"required,max=5000000"`
@@ -171,9 +171,8 @@ type SecretFileDetailsConfig30 struct {
 
 type SecretFileDetailsConfig31 struct {
 	SecretDetailsBaseConfig
-	Owners      []OwnerDetailsGroupId `json:",omitempty" validate:"required_if=OwnerType User"`
+	Owners      []OwnerDetailsGroupId `json:",omitempty" validate:"required"`
 	FileName    string                `json:",omitempty" validate:"required,max=256"`
-	OwnerType   string                `json:",omitempty" validate:"required,oneof=User Group"`
 	FileContent string                `json:",omitempty" validate:"required,max=5000000"`
 }
 

--- a/api/entities/entities.go
+++ b/api/entities/entities.go
@@ -132,6 +132,24 @@ type SecretCredentialDetails struct {
 	PasswordRuleID int            `json:",omitempty" validate:"omitempty"`
 }
 
+type SecretCredentialDetailsConfig30 struct {
+	SecretDetailsBaseConfig
+	Username       string                `json:",omitempty" validate:"required"`
+	Password       string                `json:",omitempty" validate:"max=256,required_without=PasswordRuleID"`
+	OwnerId        int                   `json:",omitempty" validate:"required_if=OwnerType Group"`
+	OwnerType      string                `json:",omitempty" validate:"required,oneof=User Group"`
+	Owners         []OwnerDetailsOwnerId `json:",omitempty" validate:"required_if=OwnerType User"`
+	PasswordRuleID int                   `json:",omitempty" validate:"omitempty"`
+}
+
+type SecretCredentialDetailsConfig31 struct {
+	SecretDetailsBaseConfig
+	Username       string                `json:",omitempty" validate:"required"`
+	Password       string                `json:",omitempty" validate:"max=256,required_without=PasswordRuleID"`
+	Owners         []OwnerDetailsGroupId `json:",omitempty" validate:"required_if=OwnerType User"`
+	PasswordRuleID int                   `json:",omitempty" validate:"omitempty"`
+}
+
 type SecretTextDetails struct {
 	Title       string         `json:",omitempty" validate:"required,max=256"`
 	Description string         `json:",omitempty" validate:"omitempty,max=256"`
@@ -142,6 +160,29 @@ type SecretTextDetails struct {
 	Notes       string         `json:",omitempty" validate:"omitempty,max=4000"`
 	FolderId    uuid.UUID      `json:",omitempty" validate:"omitempty"`
 	Urls        []UrlDetails   `json:",omitempty" validate:"omitempty"`
+}
+
+type SecretDetailsBaseConfig struct {
+	Title       string       `json:",omitempty" validate:"required,max=256"`
+	Description string       `json:",omitempty" validate:"omitempty,max=256"`
+	Notes       string       `json:",omitempty" validate:"omitempty,max=4000"`
+	Urls        []UrlDetails `json:",omitempty" validate:"omitempty"`
+}
+
+type SecretTextDetailsConfig30 struct {
+	SecretDetailsBaseConfig
+	Text      string                `json:",omitempty" validate:"required,max=4096"`
+	OwnerId   int                   `json:",omitempty" validate:"required_if=OwnerType Group"`
+	OwnerType string                `json:",omitempty" validate:"required,oneof=User Group"`
+	Owners    []OwnerDetailsOwnerId `json:",omitempty" validate:"required_if=OwnerType User"`
+	FolderId  uuid.UUID             `json:",omitempty" validate:"omitempty"`
+}
+
+type SecretTextDetailsConfig31 struct {
+	SecretDetailsBaseConfig
+	Text     string                `json:",omitempty" validate:"required,max=4096"`
+	Owners   []OwnerDetailsGroupId `json:",omitempty" validate:"required_if=OwnerType User"`
+	FolderId uuid.UUID             `json:",omitempty" validate:"omitempty"`
 }
 
 type SecretFileDetails struct {
@@ -156,10 +197,39 @@ type SecretFileDetails struct {
 	Urls        []UrlDetails   `json:",omitempty" validate:"omitempty"`
 }
 
+type SecretFileDetailsConfig30 struct {
+	SecretDetailsBaseConfig
+	OwnerId     int                   `json:",omitempty" validate:"required_if=OwnerType Group"`
+	OwnerType   string                `json:",omitempty" validate:"required,oneof=User Group"`
+	Owners      []OwnerDetailsOwnerId `json:",omitempty" validate:"required_if=OwnerType User"`
+	FileName    string                `json:",omitempty" validate:"required,max=256"`
+	FileContent string                `json:",omitempty" validate:"required,max=5000000"`
+}
+
+type SecretFileDetailsConfig31 struct {
+	SecretDetailsBaseConfig
+	Owners      []OwnerDetailsGroupId `json:",omitempty" validate:"required_if=OwnerType User"`
+	FileName    string                `json:",omitempty" validate:"required,max=256"`
+	FileContent string                `json:",omitempty" validate:"required,max=5000000"`
+}
+
 type OwnerDetails struct {
 	GroupId int    `json:",omitempty" validate:"required,min=1,max=2147483647"`
 	OwnerId int    `json:",omitempty" validate:"required,min=1,max=2147483647"`
 	Owner   string `json:",omitempty" validate:"omitempty"`
+	Email   string `json:",omitempty" validate:"omitempty"`
+}
+
+type OwnerDetailsOwnerId struct {
+	OwnerId int    `json:",omitempty" validate:"required,min=1,max=2147483647"`
+	Owner   string `json:",omitempty" validate:"omitempty"`
+	Email   string `json:",omitempty" validate:"omitempty"`
+}
+
+type OwnerDetailsGroupId struct {
+	GroupId int    `json:",omitempty" validate:"required,min=1,max=2147483647"`
+	UserId  int    `json:",omitempty" validate:"required,min=1,max=2147483647"`
+	Name    string `json:",omitempty" validate:"omitempty"`
 	Email   string `json:",omitempty" validate:"omitempty"`
 }
 

--- a/api/secrets/secrets.go
+++ b/api/secrets/secrets.go
@@ -299,30 +299,39 @@ func (secretObj *SecretObj) CreateSecretFlow(folderTarget string, secretDetails 
 
 // SecretCreateFileSecret create a secret of type file.
 func (secretObj *SecretObj) SecretCreateFileSecret(SecretCreateSecretUrl string, payload string, secretDetails interface{}) (entities.CreateSecretResponse, error) {
-	var fileSecret entities.SecretFileDetails
-	var ok bool
+
+	var fileName string
+	var fileContent string
 
 	var CreateSecretResponse entities.CreateSecretResponse
 
-	if fileSecret, ok = secretDetails.(entities.SecretFileDetails); ok {
-		body, err := secretObj.authenticationObj.HttpClient.CreateMultiPartRequest(SecretCreateSecretUrl, fileSecret.FileName, []byte(payload), fileSecret.FileContent)
-		if err != nil {
-			return entities.CreateSecretResponse{}, err
-		}
-
-		defer body.Close()
-		bodyBytes, err := io.ReadAll(body)
-
-		if err != nil {
-			return entities.CreateSecretResponse{}, err
-		}
-
-		err = json.Unmarshal([]byte(bodyBytes), &CreateSecretResponse)
-
-		if err != nil {
-			return entities.CreateSecretResponse{}, err
-		}
+	switch fileSecret := secretDetails.(type) {
+	case entities.SecretFileDetailsConfig30:
+		fileName = fileSecret.FileName
+		fileContent = fileSecret.FileContent
+	case entities.SecretFileDetailsConfig31:
+		fileName = fileSecret.FileName
+		fileContent = fileSecret.FileContent
 	}
+
+	body, err := secretObj.authenticationObj.HttpClient.CreateMultiPartRequest(SecretCreateSecretUrl, fileName, []byte(payload), fileContent)
+	if err != nil {
+		return entities.CreateSecretResponse{}, err
+	}
+
+	defer body.Close()
+	bodyBytes, err := io.ReadAll(body)
+
+	if err != nil {
+		return entities.CreateSecretResponse{}, err
+	}
+
+	err = json.Unmarshal([]byte(bodyBytes), &CreateSecretResponse)
+
+	if err != nil {
+		return entities.CreateSecretResponse{}, err
+	}
+
 	return CreateSecretResponse, nil
 
 }
@@ -359,30 +368,12 @@ func (secretObj *SecretObj) SecretCreateSecret(folderId string, secretDetails in
 		secretCredentialDetailsJson = string(bytes)
 	}
 
-	if err != nil {
-		return entities.CreateSecretResponse{}, err
-	}
-
 	payload := string(secretCredentialDetailsJson)
 
 	b := bytes.NewBufferString(payload)
 
 	// path depends on the type of secret (credential, text, file).
-	var path string
-	switch secretDetails.(type) {
-	case entities.SecretCredentialDetailsConfig30:
-		path = "secrets"
-	case entities.SecretCredentialDetailsConfig31:
-		path = "secrets"
-	case entities.SecretTextDetailsConfig30:
-		path = "secrets/text"
-	case entities.SecretTextDetailsConfig31:
-		path = "secrets/text"
-	case entities.SecretFileDetailsConfig30:
-		path = "secrets/file"
-	case entities.SecretFileDetailsConfig31:
-		path = "secrets/file"
-	}
+	path := secretObj.GetPathToCreateSecret(secretDetails)
 
 	SecretCreateSecretUrl := secretObj.authenticationObj.ApiUrl.JoinPath("secrets-safe/folders", folderId, path).String()
 
@@ -438,6 +429,27 @@ func (secretObj *SecretObj) SecretCreateSecret(folderId string, secretDetails in
 
 	return CreateSecretResponse, nil
 
+}
+
+// GetPathToCreateSecret get endpoint path.
+func (secretObj *SecretObj) GetPathToCreateSecret(secretDetails interface{}) string {
+	// path depends on the type of secret (credential, text, file).
+	var path string
+	switch secretDetails.(type) {
+	case entities.SecretCredentialDetailsConfig30:
+		path = "secrets"
+	case entities.SecretCredentialDetailsConfig31:
+		path = "secrets"
+	case entities.SecretTextDetailsConfig30:
+		path = "secrets/text"
+	case entities.SecretTextDetailsConfig31:
+		path = "secrets/text"
+	case entities.SecretFileDetailsConfig30:
+		path = "secrets/file"
+	case entities.SecretFileDetailsConfig31:
+		path = "secrets/file"
+	}
+	return path
 }
 
 // SecretGetFoldersFlow get folders list

--- a/api/secrets/secrets.go
+++ b/api/secrets/secrets.go
@@ -314,7 +314,7 @@ func (secretObj *SecretObj) SecretCreateFileSecret(SecretCreateSecretUrl string,
 		fileContent = fileSecret.FileContent
 	}
 
-	body, err := secretObj.authenticationObj.HttpClient.CreateMultiPartRequest(SecretCreateSecretUrl, fileName, []byte(payload), fileContent)
+	body, err := secretObj.authenticationObj.HttpClient.CreateMultiPartRequest(SecretCreateSecretUrl, fileName, []byte(payload), fileContent, secretObj.authenticationObj.ApiVersion)
 	if err != nil {
 		return entities.CreateSecretResponse{}, err
 	}

--- a/api/secrets/secrets.go
+++ b/api/secrets/secrets.go
@@ -19,6 +19,8 @@ import (
 	"github.com/google/uuid"
 
 	backoff "github.com/cenkalti/backoff/v4"
+
+	urlnet "net/url"
 )
 
 // SecretObj responsible for session requests.
@@ -157,6 +159,12 @@ func (secretObj *SecretObj) SecretGetSecretByPath(secretPath string, secretTitle
 	}
 
 	url := secretObj.authenticationObj.ApiUrl.JoinPath(endpointPath).String()
+
+	parsedUrl, _ := urlnet.Parse(url)
+	parsedUrl.RawQuery = params.Encode()
+
+	url = parsedUrl.String()
+
 	messageLog := fmt.Sprintf("%v %v", "GET", url)
 	secretObj.log.Debug(messageLog)
 
@@ -168,7 +176,7 @@ func (secretObj *SecretObj) SecretGetSecretByPath(secretPath string, secretTitle
 		AccessToken: "",
 		ApiKey:      "",
 		ContentType: "application/json",
-		ApiVersion:  secretObj.authenticationObj.ApiVersion,
+		ApiVersion:  "",
 	}
 
 	technicalError = backoff.Retry(func() error {

--- a/api/secrets/secrets.go
+++ b/api/secrets/secrets.go
@@ -192,7 +192,7 @@ func (secretObj *SecretObj) SecretGetSecretByPath(secretPath string, secretTitle
 		return entities.Secret{}, businessError
 	}
 
-	defer body.Close()
+	defer func() { _ = body.Close() }()
 	bodyBytes, err := io.ReadAll(body)
 
 	if err != nil {
@@ -252,7 +252,7 @@ func (secretObj *SecretObj) SecretGetFileSecret(secretId string, endpointPath st
 		return "", businessError
 	}
 
-	defer body.Close()
+	defer func() { _ = body.Close() }()
 	responseData, err := io.ReadAll(body)
 	if err != nil {
 		return "", err
@@ -327,7 +327,7 @@ func (secretObj *SecretObj) SecretCreateFileSecret(SecretCreateSecretUrl string,
 		return entities.CreateSecretResponse{}, err
 	}
 
-	defer body.Close()
+	defer func() { _ = body.Close() }()
 	bodyBytes, err := io.ReadAll(body)
 
 	if err != nil {
@@ -403,7 +403,7 @@ func (secretObj *SecretObj) SecretCreateSecret(folderId string, secretDetails in
 		return entities.CreateSecretResponse{}, businessError
 	}
 
-	defer body.Close()
+	defer func() { _ = body.Close() }()
 	bodyBytes, err := io.ReadAll(body)
 
 	if err != nil {
@@ -614,7 +614,7 @@ func (secretObj *SecretObj) SecretCreateFolder(folderDetails entities.FolderDeta
 		return entities.CreateFolderResponse{}, businessError
 	}
 
-	defer body.Close()
+	defer func() { _ = body.Close() }()
 	bodyBytes, err := io.ReadAll(body)
 
 	if err != nil {

--- a/api/secrets/secrets.go
+++ b/api/secrets/secrets.go
@@ -343,30 +343,12 @@ func (secretObj *SecretObj) SecretCreateSecret(folderId string, secretDetails in
 	var secretCredentialDetailsJson string
 	var err error
 
-	switch managedSystemDetails := secretDetails.(type) {
-
-	// validate request body according to the API Version.
-	case entities.SecretCredentialDetailsConfig30,
-		entities.SecretCredentialDetailsConfig31,
-		entities.SecretTextDetailsConfig30,
-		entities.SecretTextDetailsConfig31,
-		entities.SecretFileDetailsConfig30,
-		entities.SecretFileDetailsConfig31:
-
-		err = utils.ValidateData(managedSystemDetails)
-		if err != nil {
-			return CreateSecretResponse, err
-		}
-
-		var bytes []byte
-
-		// Convert object to json string.
-		bytes, err = json.Marshal(managedSystemDetails)
-		if err != nil {
-			return CreateSecretResponse, err
-		}
-		secretCredentialDetailsJson = string(bytes)
+	// Convert object to json string.
+	secretDetailsJson, err := json.Marshal(secretDetails)
+	if err != nil {
+		return CreateSecretResponse, err
 	}
+	secretCredentialDetailsJson = string(secretDetailsJson)
 
 	payload := string(secretCredentialDetailsJson)
 

--- a/api/secrets/secrets_test.go
+++ b/api/secrets/secrets_test.go
@@ -873,7 +873,6 @@ func TestSecretCreateFileSecretFlow(t *testing.T) {
 		SecretDetailsBaseConfig: secretDetailsConfig,
 		FileName:                "textfile.txt",
 		FileContent:             "Secret Content",
-		OwnerType:               "User",
 		Owners: []entities.OwnerDetailsGroupId{
 			{
 				UserId: 1,

--- a/api/secrets/secrets_test.go
+++ b/api/secrets/secrets_test.go
@@ -898,15 +898,6 @@ func TestSecretCreateFileSecretFlowError(t *testing.T) {
 		Description: "File Title Description",
 	}
 
-	var owners []entities.OwnerDetailsOwnerId
-
-	mainOwner := entities.OwnerDetailsOwnerId{
-		OwnerId: 1,
-		Owner:   "test",
-		Email:   "test@test.com",
-	}
-	owners = append(owners, mainOwner)
-
 	secretTextDetails := entities.SecretFileDetailsConfig30{
 		SecretDetailsBaseConfig: secretDetailsConfig,
 		FileName:                "textfile.txt",

--- a/api/secrets/secrets_test.go
+++ b/api/secrets/secrets_test.go
@@ -642,7 +642,8 @@ func TestSecretCreateTextSecretFlow(t *testing.T) {
 		Description: "Title Description",
 	}
 
-	secretTextDetails := entities.SecretTextDetailsConfig30{
+	// Test with API Version 3.0
+	secretTextDetails30 := entities.SecretTextDetailsConfig30{
 		SecretDetailsBaseConfig: secretDetailsConfig,
 		Text:                    constants.FakePassword,
 		OwnerType:               "User",
@@ -657,7 +658,35 @@ func TestSecretCreateTextSecretFlow(t *testing.T) {
 		},
 	}
 
-	response, err := secretObj.CreateSecretFlow("folder1", secretTextDetails)
+	response, err := secretObj.CreateSecretFlow("folder1", secretTextDetails30)
+
+	if response.Title != "Secret Title" {
+		t.Errorf("Test case Failed %v, %v", response, testConfig.response)
+	}
+
+	if response.Description != "Title Description" {
+		t.Errorf("Test case Failed %v, %v", response, testConfig.response)
+	}
+
+	if err != nil {
+		t.Errorf("Test case Failed: %v", err)
+	}
+
+	// Test with API Version 3.1.
+	secretTextDetails31 := entities.SecretTextDetailsConfig31{
+		SecretDetailsBaseConfig: secretDetailsConfig,
+		Text:                    constants.FakePassword,
+		FolderId:                uuid.New(),
+		Owners: []entities.OwnerDetailsGroupId{
+			{
+				UserId: 1,
+				Name:   "administrator",
+				Email:  "test@beyondtrust.com",
+			},
+		},
+	}
+
+	response, err = secretObj.CreateSecretFlow("folder1", secretTextDetails31)
 
 	if response.Title != "Secret Title" {
 		t.Errorf("Test case Failed %v, %v", response, testConfig.response)
@@ -711,6 +740,7 @@ func TestSecretCreateCredentialSecretFlow(t *testing.T) {
 		Description: "Title Description",
 	}
 
+	// Test with API Version 3.0
 	secretTextDetails := entities.SecretCredentialDetailsConfig30{
 		SecretDetailsBaseConfig: secretDetailsConfig,
 		Username:                "TestUserName",
@@ -727,6 +757,34 @@ func TestSecretCreateCredentialSecretFlow(t *testing.T) {
 	}
 
 	response, err := secretObj.CreateSecretFlow("folder1", secretTextDetails)
+
+	if response.Title != "Secret Title" {
+		t.Errorf("Test case Failed %v, %v", response, testConfig.response)
+	}
+
+	if response.Description != "Title Description" {
+		t.Errorf("Test case Failed %v, %v", response, testConfig.response)
+	}
+
+	if err != nil {
+		t.Errorf("Test case Failed: %v", err)
+	}
+
+	// Test with API Version 3.1
+	secretTextDetails31 := entities.SecretCredentialDetailsConfig31{
+		SecretDetailsBaseConfig: secretDetailsConfig,
+		Username:                "TestUserName",
+		Password:                constants.FakePassword,
+		Owners: []entities.OwnerDetailsGroupId{
+			{
+				UserId: 1,
+				Name:   "administrator",
+				Email:  "test@beyondtrust.com",
+			},
+		},
+	}
+
+	response, err = secretObj.CreateSecretFlow("folder1", secretTextDetails31)
 
 	if response.Title != "Secret Title" {
 		t.Errorf("Test case Failed %v, %v", response, testConfig.response)
@@ -780,7 +838,8 @@ func TestSecretCreateFileSecretFlow(t *testing.T) {
 		Description: "File Title Description",
 	}
 
-	secretTextDetails := entities.SecretFileDetailsConfig30{
+	// Test with API Version 3.0
+	secretTextDetails30 := entities.SecretFileDetailsConfig30{
 		SecretDetailsBaseConfig: secretDetailsConfig,
 		FileName:                "textfile.txt",
 		FileContent:             "Secret Content",
@@ -795,7 +854,36 @@ func TestSecretCreateFileSecretFlow(t *testing.T) {
 		},
 	}
 
-	response, err := secretObj.CreateSecretFlow("folder1", secretTextDetails)
+	response, err := secretObj.CreateSecretFlow("folder1", secretTextDetails30)
+
+	if response.Title != "File Secret Title" {
+		t.Errorf("Test case Failed %v, %v", response, "File Secret Title")
+	}
+
+	if response.Description != "Title Description" {
+		t.Errorf("Test case Failed %v, %v", response, "Title Description")
+	}
+
+	if err != nil {
+		t.Errorf("Test case Failed: %v", err)
+	}
+
+	// Test with API Version 3.1
+	secretTextDetails31 := entities.SecretFileDetailsConfig31{
+		SecretDetailsBaseConfig: secretDetailsConfig,
+		FileName:                "textfile.txt",
+		FileContent:             "Secret Content",
+		OwnerType:               "User",
+		Owners: []entities.OwnerDetailsGroupId{
+			{
+				UserId: 1,
+				Name:   "administrator",
+				Email:  "test@beyondtrust.com",
+			},
+		},
+	}
+
+	response, err = secretObj.CreateSecretFlow("folder1", secretTextDetails31)
 
 	if response.Title != "File Secret Title" {
 		t.Errorf("Test case Failed %v, %v", response, "File Secret Title")

--- a/api/secrets/secrets_test.go
+++ b/api/secrets/secrets_test.go
@@ -637,14 +637,18 @@ func TestSecretCreateTextSecretFlow(t *testing.T) {
 	authenticate.ApiUrl = *apiUrl
 	secretObj, _ := NewSecretObj(*authenticate, zapLogger, 4000)
 
-	secretTextDetails := entities.SecretTextDetails{
+	secretDetailsConfig := entities.SecretDetailsBaseConfig{
 		Title:       "Secret Title",
 		Description: "Title Description",
-		Text:        constants.FakePassword,
-		OwnerType:   "User",
-		OwnerId:     1,
-		FolderId:    uuid.New(),
-		Owners: []entities.OwnerDetails{
+	}
+
+	secretTextDetails := entities.SecretTextDetailsConfig30{
+		SecretDetailsBaseConfig: secretDetailsConfig,
+		Text:                    constants.FakePassword,
+		OwnerType:               "User",
+		OwnerId:                 1,
+		FolderId:                uuid.New(),
+		Owners: []entities.OwnerDetailsOwnerId{
 			{
 				OwnerId: 1,
 				Owner:   "administrator",
@@ -702,14 +706,18 @@ func TestSecretCreateCredentialSecretFlow(t *testing.T) {
 	authenticate.ApiUrl = *apiUrl
 	secretObj, _ := NewSecretObj(*authenticate, zapLogger, 4000)
 
-	secretTextDetails := entities.SecretCredentialDetails{
+	secretDetailsConfig := entities.SecretDetailsBaseConfig{
 		Title:       "Secret Title",
 		Description: "Title Description",
-		Username:    "TestUserName",
-		Password:    constants.FakePassword,
-		OwnerType:   "User",
-		OwnerId:     1,
-		Owners: []entities.OwnerDetails{
+	}
+
+	secretTextDetails := entities.SecretCredentialDetailsConfig30{
+		SecretDetailsBaseConfig: secretDetailsConfig,
+		Username:                "TestUserName",
+		Password:                constants.FakePassword,
+		OwnerType:               "User",
+		OwnerId:                 1,
+		Owners: []entities.OwnerDetailsOwnerId{
 			{
 				OwnerId: 1,
 				Owner:   "administrator",
@@ -767,14 +775,18 @@ func TestSecretCreateFileSecretFlow(t *testing.T) {
 	authenticate.ApiUrl = *apiUrl
 	secretObj, _ := NewSecretObj(*authenticate, zapLogger, 4000)
 
-	secretTextDetails := entities.SecretFileDetails{
+	secretDetailsConfig := entities.SecretDetailsBaseConfig{
 		Title:       "Secret Title",
 		Description: "File Title Description",
-		FileName:    "textfile.txt",
-		FileContent: "Secret Content",
-		OwnerType:   "User",
-		OwnerId:     1,
-		Owners: []entities.OwnerDetails{
+	}
+
+	secretTextDetails := entities.SecretFileDetailsConfig30{
+		SecretDetailsBaseConfig: secretDetailsConfig,
+		FileName:                "textfile.txt",
+		FileContent:             "Secret Content",
+		OwnerType:               "User",
+		OwnerId:                 1,
+		Owners: []entities.OwnerDetailsOwnerId{
 			{
 				OwnerId: 1,
 				Owner:   "administrator",
@@ -818,14 +830,18 @@ func TestSecretCreateFileSecretFlowErrorFileContent(t *testing.T) {
 	n := 5_000_001
 	fileContent := strings.Repeat("A", n)
 
-	secretTextDetails := entities.SecretFileDetails{
+	secretDetailsConfig := entities.SecretDetailsBaseConfig{
 		Title:       "Secret Title",
 		Description: "File Title Description",
-		FileName:    "textfile.txt",
-		FileContent: fileContent,
-		OwnerType:   "User",
-		OwnerId:     1,
-		Owners: []entities.OwnerDetails{
+	}
+
+	secretTextDetails := entities.SecretFileDetailsConfig30{
+		SecretDetailsBaseConfig: secretDetailsConfig,
+		FileName:                "textfile.txt",
+		FileContent:             fileContent,
+		OwnerType:               "User",
+		OwnerId:                 1,
+		Owners: []entities.OwnerDetailsOwnerId{
 			{
 				OwnerId: 1,
 				Owner:   "administrator",
@@ -877,14 +893,27 @@ func TestSecretCreateFileSecretFlowError(t *testing.T) {
 	authenticate.ApiUrl = *apiUrl
 	secretObj, _ := NewSecretObj(*authenticate, zapLogger, 4000)
 
-	secretTextDetails := entities.SecretFileDetails{
+	secretDetailsConfig := entities.SecretDetailsBaseConfig{
 		Title:       "Secret Title",
 		Description: "File Title Description",
-		FileName:    "textfile.txt",
-		FileContent: "Secret Content",
-		OwnerType:   "User",
-		OwnerId:     1,
-		Owners: []entities.OwnerDetails{
+	}
+
+	var owners []entities.OwnerDetailsOwnerId
+
+	mainOwner := entities.OwnerDetailsOwnerId{
+		OwnerId: 1,
+		Owner:   "test",
+		Email:   "test@test.com",
+	}
+	owners = append(owners, mainOwner)
+
+	secretTextDetails := entities.SecretFileDetailsConfig30{
+		SecretDetailsBaseConfig: secretDetailsConfig,
+		FileName:                "textfile.txt",
+		FileContent:             "Secret Content",
+		OwnerType:               "User",
+		OwnerId:                 1,
+		Owners: []entities.OwnerDetailsOwnerId{
 			{
 				OwnerId: 1,
 				Owner:   "administrator",
@@ -939,14 +968,17 @@ func TestSecretCreateBadInput(t *testing.T) {
 	authenticate.ApiUrl = *apiUrl
 	secretObj, _ := NewSecretObj(*authenticate, zapLogger, 4000)
 
-	secretTextDetails := entities.SecretCredentialDetails{
-		Title:       "",
+	secretDetailsConfig := entities.SecretDetailsBaseConfig{
 		Description: "Title Description",
-		Username:    "TestUserName",
-		Password:    constants.FakePassword,
-		OwnerType:   "User",
-		OwnerId:     1,
-		Owners: []entities.OwnerDetails{
+	}
+
+	secretTextDetails := entities.SecretCredentialDetailsConfig30{
+		SecretDetailsBaseConfig: secretDetailsConfig,
+		Username:                "TestUserName",
+		Password:                constants.FakePassword,
+		OwnerType:               "User",
+		OwnerId:                 1,
+		Owners: []entities.OwnerDetailsOwnerId{
 			{
 				OwnerId: 1,
 				Owner:   "administrator",
@@ -991,14 +1023,18 @@ func TestSecretCreateSecretFlowFolderNotFound(t *testing.T) {
 	authenticate.ApiUrl = *apiUrl
 	secretObj, _ := NewSecretObj(*authenticate, zapLogger, 4000)
 
-	secretTextDetails := entities.SecretTextDetails{
+	secretDetailsConfig := entities.SecretDetailsBaseConfig{
 		Title:       "Secret Title",
 		Description: "Title Description",
-		Text:        constants.FakePassword,
-		OwnerType:   "User",
-		OwnerId:     1,
-		FolderId:    uuid.New(),
-		Owners: []entities.OwnerDetails{
+	}
+
+	secretTextDetails := entities.SecretTextDetailsConfig30{
+		SecretDetailsBaseConfig: secretDetailsConfig,
+		Text:                    constants.FakePassword,
+		OwnerType:               "User",
+		OwnerId:                 1,
+		FolderId:                uuid.New(),
+		Owners: []entities.OwnerDetailsOwnerId{
 			{
 				OwnerId: 1,
 				Owner:   "administrator",
@@ -1043,14 +1079,18 @@ func TestSecretCreateSecretFlowEmptyFolderList(t *testing.T) {
 	authenticate.ApiUrl = *apiUrl
 	secretObj, _ := NewSecretObj(*authenticate, zapLogger, 4000)
 
-	secretTextDetails := entities.SecretTextDetails{
+	secretDetailsConfig := entities.SecretDetailsBaseConfig{
 		Title:       "Secret Title",
 		Description: "Title Description",
-		Text:        constants.FakePassword,
-		OwnerType:   "User",
-		OwnerId:     1,
-		FolderId:    uuid.New(),
-		Owners: []entities.OwnerDetails{
+	}
+
+	secretTextDetails := entities.SecretTextDetailsConfig30{
+		SecretDetailsBaseConfig: secretDetailsConfig,
+		Text:                    constants.FakePassword,
+		OwnerType:               "User",
+		OwnerId:                 1,
+		FolderId:                uuid.New(),
+		Owners: []entities.OwnerDetailsOwnerId{
 			{
 				OwnerId: 1,
 				Owner:   "administrator",

--- a/api/utils/httpclient.go
+++ b/api/utils/httpclient.go
@@ -229,7 +229,7 @@ func (client *HttpClientObj) HttpRequest(url string, method string, body bytes.B
 }
 
 // CreateMultipartRequest creates and sends multipart request.
-func (client *HttpClientObj) CreateMultiPartRequest(url, fileName string, metadata []byte, fileContent string) (io.ReadCloser, error) {
+func (client *HttpClientObj) CreateMultiPartRequest(url, fileName string, metadata []byte, fileContent string, apiVersion string) (io.ReadCloser, error) {
 
 	var requestBody bytes.Buffer
 
@@ -255,6 +255,7 @@ func (client *HttpClientObj) CreateMultiPartRequest(url, fileName string, metada
 	multipartWriter.Close()
 
 	callSecretSafeAPIObj := &entities.CallSecretSafeAPIObj{
+		ApiVersion:  apiVersion,
 		Url:         url,
 		HttpMethod:  "POST",
 		Body:        requestBody,

--- a/api/utils/httpclient_test.go
+++ b/api/utils/httpclient_test.go
@@ -213,7 +213,7 @@ func TestCreateMultiPartRequest(t *testing.T) {
 	zapLogger := logging.NewZapLogger(logger)
 
 	httpClientObj, _ := GetHttpClient(30, false, "", "", zapLogger)
-	_, err := httpClientObj.CreateMultiPartRequest(server.URL+"/secrets/file", "file_name.txt", []byte("metadata"), "file_content")
+	_, err := httpClientObj.CreateMultiPartRequest(server.URL+"/secrets/file", "file_name.txt", []byte("metadata"), "file_content", constants.ApiVersion31)
 
 	if err != nil {
 		t.Errorf("Test case Failed: %v", err)


### PR DESCRIPTION
### Purpose of the PR
Add support for API version (3.0, 3.1) in create credential, text and file features.

### According to ticket
<!-- Jira url or ticket number -->
https://beyondtrust.atlassian.net/browse/BIPS-27413

### Summary of changes:

Add support API support for the next resources:

- passwordsafe_credential_secret
- passwordsafe_text_secret
- passwordsafe_file_secret

Update unit tests cases.
Update TestClient.go script.
Add needed entities to support versions (3.0/3.1)
Call CreateManagedSystem method in TestClient.go test script.
Fix issue in get secret by path datasource: https://beyondtrust.atlassian.net/browse/BIPS-27415
Set default value for timeout attribute in create managed system resources: https://beyondtrust.atlassian.net/browse/BIPS-27438