### PR TITLE
feat: add support for API version (3.0, 3.1) in create credential, te…

### DIFF
--- a/TestClient.go
+++ b/TestClient.go
@@ -212,6 +212,12 @@ func main() {
 		return
 	}
 
+	err = CreateManagedSystem(authenticate, zapLogger)
+	if err != nil {
+		zapLogger.Error(err.Error())
+		return
+	}
+
 	// signing out
 	err = authenticate.SignOut()
 
@@ -336,26 +342,31 @@ func CreateManagedAccount(authenticationObj *authentication.AuthenticationObj, z
 func CreateSecretsAndFolders(authenticationObj *authentication.AuthenticationObj, zapLogger *logging.ZapLogger, userObject entities.SignAppinResponse, maxFileSecretSizeBytes int) error {
 
 	secretObj, _ := secrets.NewSecretObj(*authenticationObj, zapLogger, maxFileSecretSizeBytes)
-	objCredential := entities.SecretCredentialDetails{
+
+	secretDetailsConfig := entities.SecretDetailsBaseConfig{
 		Title:       "CREDENTIAL_" + identifier,
 		Description: "My Credential Secret Description",
-		Username:    "my_user",
-		Password:    constants.FakePassword,
-		OwnerType:   "User",
 		Notes:       "My note",
-		Owners: []entities.OwnerDetails{
-			{
-				GroupId: 1,
-				OwnerId: userObject.UserId,
-				Owner:   userObject.UserName,
-				Email:   userObject.EmailAddress,
-			},
-		},
 		Urls: []entities.UrlDetails{
 			{
 				Id:           uuid.New(),
 				CredentialId: uuid.New(),
 				Url:          "https://www.test.com/",
+			},
+		},
+	}
+
+	objCredential := entities.SecretCredentialDetailsConfig31{
+		SecretDetailsBaseConfig: secretDetailsConfig,
+		Username:                "my_user",
+		Password:                constants.FakePassword,
+
+		Owners: []entities.OwnerDetailsGroupId{
+			{
+				GroupId: 1,
+				UserId:  userObject.UserId,
+				Name:    userObject.UserName,
+				Email:   userObject.EmailAddress,
 			},
 		},
 	}
@@ -370,26 +381,27 @@ func CreateSecretsAndFolders(authenticationObj *authentication.AuthenticationObj
 	// WARNING: Do not log secrets in production code, the following log statement logs test secrets for testing purposes:
 	zapLogger.Debug(fmt.Sprintf("Created Credential secret: %v", createdSecret.Title))
 
-	objText := entities.SecretTextDetails{
+	secretDetailsConfig = entities.SecretDetailsBaseConfig{
 		Title:       "TEXT_" + identifier,
 		Description: "My Text Secret Description",
-		Text:        constants.FakePassword,
-		OwnerType:   "User",
-		OwnerId:     userObject.UserId,
-		FolderId:    uuid.New(),
-		Owners: []entities.OwnerDetails{
-			{
-				GroupId: 1,
-				OwnerId: userObject.UserId,
-				Owner:   userObject.UserName,
-				Email:   userObject.EmailAddress,
-			},
-		},
 		Urls: []entities.UrlDetails{
 			{
 				Id:           uuid.New(),
 				CredentialId: uuid.New(),
 				Url:          "https://www.test.com/",
+			},
+		},
+	}
+
+	objText := entities.SecretTextDetailsConfig31{
+		SecretDetailsBaseConfig: secretDetailsConfig,
+		Text:                    constants.FakePassword,
+		FolderId:                uuid.New(),
+		Owners: []entities.OwnerDetailsGroupId{
+			{
+				UserId: userObject.UserId,
+				Name:   userObject.UserName,
+				Email:  userObject.EmailAddress,
 			},
 		},
 	}
@@ -411,22 +423,10 @@ func CreateSecretsAndFolders(authenticationObj *authentication.AuthenticationObj
 		return nil
 	}
 
-	objFile := entities.SecretFileDetails{
+	secretDetailsConfig = entities.SecretDetailsBaseConfig{
 		Title:       "FILE_" + identifier,
 		Description: "My File Secret Description",
-		OwnerType:   "User",
-		OwnerId:     userObject.UserId,
-		Owners: []entities.OwnerDetails{
-			{
-				GroupId: 1,
-				OwnerId: userObject.UserId,
-				Owner:   userObject.UserName,
-				Email:   userObject.EmailAddress,
-			},
-		},
 		Notes:       "Notes 1",
-		FileName:    "my_secret.txt",
-		FileContent: string(fileContent),
 		Urls: []entities.UrlDetails{
 			{
 				Id:           uuid.New(),
@@ -434,6 +434,20 @@ func CreateSecretsAndFolders(authenticationObj *authentication.AuthenticationObj
 				Url:          "https://www.test.com/",
 			},
 		},
+	}
+
+	objFile := entities.SecretFileDetailsConfig31{
+		SecretDetailsBaseConfig: secretDetailsConfig,
+		Owners: []entities.OwnerDetailsGroupId{
+			{
+				UserId: userObject.UserId,
+				Name:   userObject.UserName,
+				Email:  userObject.EmailAddress,
+			},
+		},
+
+		FileName:    "my_secret.txt",
+		FileContent: string(fileContent),
 	}
 
 	// creating a file secret in folder1.

--- a/api/entities/entities.go
+++ b/api/entities/entities.go
@@ -119,47 +119,73 @@ type CreateSecretResponse struct {
 	FolderId    string
 }
 
-type SecretCredentialDetails struct {
-	Title          string         `json:",omitempty" validate:"required"`
-	Description    string         `json:",omitempty" validate:"omitempty,max=256"`
-	Username       string         `json:",omitempty" validate:"required"`
-	Password       string         `json:",omitempty" validate:"max=256,required_without=PasswordRuleID"`
-	OwnerId        int            `json:",omitempty" validate:"required_if=OwnerType Group"`
-	OwnerType      string         `json:",omitempty" validate:"required,oneof=User Group"`
-	Owners         []OwnerDetails `json:",omitempty" validate:"required_if=OwnerType User"`
-	Notes          string         `json:",omitempty" validate:"omitempty,max=4000"`
-	Urls           []UrlDetails   `json:",omitempty" validate:"omitempty"`
-	PasswordRuleID int            `json:",omitempty" validate:"omitempty"`
+type SecretCredentialDetailsConfig30 struct {
+	SecretDetailsBaseConfig
+	Username       string                `json:",omitempty" validate:"required"`
+	Password       string                `json:",omitempty" validate:"max=256,required_without=PasswordRuleID"`
+	OwnerId        int                   `json:",omitempty" validate:"required_if=OwnerType Group"`
+	OwnerType      string                `json:",omitempty" validate:"required,oneof=User Group"`
+	Owners         []OwnerDetailsOwnerId `json:",omitempty" validate:"required_if=OwnerType User"`
+	PasswordRuleID int                   `json:",omitempty" validate:"omitempty"`
 }
 
-type SecretTextDetails struct {
-	Title       string         `json:",omitempty" validate:"required,max=256"`
-	Description string         `json:",omitempty" validate:"omitempty,max=256"`
-	Text        string         `json:",omitempty" validate:"required,max=4096"`
-	OwnerId     int            `json:",omitempty" validate:"required_if=OwnerType Group"`
-	OwnerType   string         `json:",omitempty" validate:"required,oneof=User Group"`
-	Owners      []OwnerDetails `json:",omitempty" validate:"required_if=OwnerType User"`
-	Notes       string         `json:",omitempty" validate:"omitempty,max=4000"`
-	FolderId    uuid.UUID      `json:",omitempty" validate:"omitempty"`
-	Urls        []UrlDetails   `json:",omitempty" validate:"omitempty"`
+type SecretCredentialDetailsConfig31 struct {
+	SecretDetailsBaseConfig
+	Username       string                `json:",omitempty" validate:"required"`
+	Password       string                `json:",omitempty" validate:"max=256,required_without=PasswordRuleID"`
+	Owners         []OwnerDetailsGroupId `json:",omitempty" validate:"required"`
+	PasswordRuleID int                   `json:",omitempty" validate:"omitempty"`
 }
 
-type SecretFileDetails struct {
-	Title       string         `json:",omitempty" validate:"required,max=256"`
-	Description string         `json:",omitempty" validate:"omitempty,max=256"`
-	OwnerId     int            `json:",omitempty" validate:"required_if=OwnerType Group"`
-	OwnerType   string         `json:",omitempty" validate:"required,oneof=User Group"`
-	Owners      []OwnerDetails `json:",omitempty" validate:"required_if=OwnerType User"`
-	Notes       string         `json:",omitempty" validate:"omitempty,max=4000"`
-	FileName    string         `json:",omitempty" validate:"required,max=256"`
-	FileContent string         `json:",omitempty" validate:"required,max=5000000"`
-	Urls        []UrlDetails   `json:",omitempty" validate:"omitempty"`
+type SecretDetailsBaseConfig struct {
+	Title       string       `json:",omitempty" validate:"required,max=256"`
+	Description string       `json:",omitempty" validate:"omitempty,max=256"`
+	Notes       string       `json:",omitempty" validate:"omitempty,max=4000"`
+	Urls        []UrlDetails `json:",omitempty" validate:"omitempty"`
 }
 
-type OwnerDetails struct {
-	GroupId int    `json:",omitempty" validate:"required,min=1,max=2147483647"`
+type SecretTextDetailsConfig30 struct {
+	SecretDetailsBaseConfig
+	Text      string                `json:",omitempty" validate:"required,max=4096"`
+	OwnerId   int                   `json:",omitempty" validate:"required_if=OwnerType Group"`
+	OwnerType string                `json:",omitempty" validate:"oneof=User Group"`
+	Owners    []OwnerDetailsOwnerId `json:",omitempty" validate:"required_if=OwnerType User"`
+	FolderId  uuid.UUID             `json:",omitempty" validate:"omitempty"`
+}
+
+type SecretTextDetailsConfig31 struct {
+	SecretDetailsBaseConfig
+	Text     string                `json:",omitempty" validate:"required,max=4096"`
+	Owners   []OwnerDetailsGroupId `json:",omitempty" validate:"required"`
+	FolderId uuid.UUID             `json:",omitempty" validate:"omitempty"`
+}
+
+type SecretFileDetailsConfig30 struct {
+	SecretDetailsBaseConfig
+	OwnerId     int                   `json:",omitempty" validate:"required_if=OwnerType Group"`
+	OwnerType   string                `json:",omitempty" validate:"oneof=User Group"`
+	Owners      []OwnerDetailsOwnerId `json:",omitempty" validate:"required_if=OwnerType User"`
+	FileName    string                `json:",omitempty" validate:"required,max=256"`
+	FileContent string                `json:",omitempty" validate:"required,max=5000000"`
+}
+
+type SecretFileDetailsConfig31 struct {
+	SecretDetailsBaseConfig
+	Owners      []OwnerDetailsGroupId `json:",omitempty" validate:"required"`
+	FileName    string                `json:",omitempty" validate:"required,max=256"`
+	FileContent string                `json:",omitempty" validate:"required,max=5000000"`
+}
+
+type OwnerDetailsOwnerId struct {
 	OwnerId int    `json:",omitempty" validate:"required,min=1,max=2147483647"`
 	Owner   string `json:",omitempty" validate:"omitempty"`
+	Email   string `json:",omitempty" validate:"omitempty"`
+}
+
+type OwnerDetailsGroupId struct {
+	GroupId int    `json:",omitempty" validate:"required,min=1,max=2147483647"`
+	UserId  int    `json:",omitempty" validate:"required,min=1,max=2147483647"`
+	Name    string `json:",omitempty" validate:"omitempty"`
 	Email   string `json:",omitempty" validate:"omitempty"`
 }
 

--- a/api/secrets/secrets_test.go
+++ b/api/secrets/secrets_test.go
@@ -637,14 +637,19 @@ func TestSecretCreateTextSecretFlow(t *testing.T) {
 	authenticate.ApiUrl = *apiUrl
 	secretObj, _ := NewSecretObj(*authenticate, zapLogger, 4000)
 
-	secretTextDetails := entities.SecretTextDetails{
+	secretDetailsConfig := entities.SecretDetailsBaseConfig{
 		Title:       "Secret Title",
 		Description: "Title Description",
-		Text:        constants.FakePassword,
-		OwnerType:   "User",
-		OwnerId:     1,
-		FolderId:    uuid.New(),
-		Owners: []entities.OwnerDetails{
+	}
+
+	// Test with API Version 3.0
+	secretTextDetails30 := entities.SecretTextDetailsConfig30{
+		SecretDetailsBaseConfig: secretDetailsConfig,
+		Text:                    constants.FakePassword,
+		OwnerType:               "User",
+		OwnerId:                 1,
+		FolderId:                uuid.New(),
+		Owners: []entities.OwnerDetailsOwnerId{
 			{
 				OwnerId: 1,
 				Owner:   "administrator",
@@ -653,7 +658,35 @@ func TestSecretCreateTextSecretFlow(t *testing.T) {
 		},
 	}
 
-	response, err := secretObj.CreateSecretFlow("folder1", secretTextDetails)
+	response, err := secretObj.CreateSecretFlow("folder1", secretTextDetails30)
+
+	if response.Title != "Secret Title" {
+		t.Errorf("Test case Failed %v, %v", response, testConfig.response)
+	}
+
+	if response.Description != "Title Description" {
+		t.Errorf("Test case Failed %v, %v", response, testConfig.response)
+	}
+
+	if err != nil {
+		t.Errorf("Test case Failed: %v", err)
+	}
+
+	// Test with API Version 3.1.
+	secretTextDetails31 := entities.SecretTextDetailsConfig31{
+		SecretDetailsBaseConfig: secretDetailsConfig,
+		Text:                    constants.FakePassword,
+		FolderId:                uuid.New(),
+		Owners: []entities.OwnerDetailsGroupId{
+			{
+				UserId: 1,
+				Name:   "administrator",
+				Email:  "test@beyondtrust.com",
+			},
+		},
+	}
+
+	response, err = secretObj.CreateSecretFlow("folder1", secretTextDetails31)
 
 	if response.Title != "Secret Title" {
 		t.Errorf("Test case Failed %v, %v", response, testConfig.response)
@@ -702,14 +735,19 @@ func TestSecretCreateCredentialSecretFlow(t *testing.T) {
 	authenticate.ApiUrl = *apiUrl
 	secretObj, _ := NewSecretObj(*authenticate, zapLogger, 4000)
 
-	secretTextDetails := entities.SecretCredentialDetails{
+	secretDetailsConfig := entities.SecretDetailsBaseConfig{
 		Title:       "Secret Title",
 		Description: "Title Description",
-		Username:    "TestUserName",
-		Password:    constants.FakePassword,
-		OwnerType:   "User",
-		OwnerId:     1,
-		Owners: []entities.OwnerDetails{
+	}
+
+	// Test with API Version 3.0
+	secretTextDetails := entities.SecretCredentialDetailsConfig30{
+		SecretDetailsBaseConfig: secretDetailsConfig,
+		Username:                "TestUserName",
+		Password:                constants.FakePassword,
+		OwnerType:               "User",
+		OwnerId:                 1,
+		Owners: []entities.OwnerDetailsOwnerId{
 			{
 				OwnerId: 1,
 				Owner:   "administrator",
@@ -719,6 +757,34 @@ func TestSecretCreateCredentialSecretFlow(t *testing.T) {
 	}
 
 	response, err := secretObj.CreateSecretFlow("folder1", secretTextDetails)
+
+	if response.Title != "Secret Title" {
+		t.Errorf("Test case Failed %v, %v", response, testConfig.response)
+	}
+
+	if response.Description != "Title Description" {
+		t.Errorf("Test case Failed %v, %v", response, testConfig.response)
+	}
+
+	if err != nil {
+		t.Errorf("Test case Failed: %v", err)
+	}
+
+	// Test with API Version 3.1
+	secretTextDetails31 := entities.SecretCredentialDetailsConfig31{
+		SecretDetailsBaseConfig: secretDetailsConfig,
+		Username:                "TestUserName",
+		Password:                constants.FakePassword,
+		Owners: []entities.OwnerDetailsGroupId{
+			{
+				UserId: 1,
+				Name:   "administrator",
+				Email:  "test@beyondtrust.com",
+			},
+		},
+	}
+
+	response, err = secretObj.CreateSecretFlow("folder1", secretTextDetails31)
 
 	if response.Title != "Secret Title" {
 		t.Errorf("Test case Failed %v, %v", response, testConfig.response)
@@ -767,14 +833,19 @@ func TestSecretCreateFileSecretFlow(t *testing.T) {
 	authenticate.ApiUrl = *apiUrl
 	secretObj, _ := NewSecretObj(*authenticate, zapLogger, 4000)
 
-	secretTextDetails := entities.SecretFileDetails{
+	secretDetailsConfig := entities.SecretDetailsBaseConfig{
 		Title:       "Secret Title",
 		Description: "File Title Description",
-		FileName:    "textfile.txt",
-		FileContent: "Secret Content",
-		OwnerType:   "User",
-		OwnerId:     1,
-		Owners: []entities.OwnerDetails{
+	}
+
+	// Test with API Version 3.0
+	secretTextDetails30 := entities.SecretFileDetailsConfig30{
+		SecretDetailsBaseConfig: secretDetailsConfig,
+		FileName:                "textfile.txt",
+		FileContent:             "Secret Content",
+		OwnerType:               "User",
+		OwnerId:                 1,
+		Owners: []entities.OwnerDetailsOwnerId{
 			{
 				OwnerId: 1,
 				Owner:   "administrator",
@@ -783,7 +854,35 @@ func TestSecretCreateFileSecretFlow(t *testing.T) {
 		},
 	}
 
-	response, err := secretObj.CreateSecretFlow("folder1", secretTextDetails)
+	response, err := secretObj.CreateSecretFlow("folder1", secretTextDetails30)
+
+	if response.Title != "File Secret Title" {
+		t.Errorf("Test case Failed %v, %v", response, "File Secret Title")
+	}
+
+	if response.Description != "Title Description" {
+		t.Errorf("Test case Failed %v, %v", response, "Title Description")
+	}
+
+	if err != nil {
+		t.Errorf("Test case Failed: %v", err)
+	}
+
+	// Test with API Version 3.1
+	secretTextDetails31 := entities.SecretFileDetailsConfig31{
+		SecretDetailsBaseConfig: secretDetailsConfig,
+		FileName:                "textfile.txt",
+		FileContent:             "Secret Content",
+		Owners: []entities.OwnerDetailsGroupId{
+			{
+				UserId: 1,
+				Name:   "administrator",
+				Email:  "test@beyondtrust.com",
+			},
+		},
+	}
+
+	response, err = secretObj.CreateSecretFlow("folder1", secretTextDetails31)
 
 	if response.Title != "File Secret Title" {
 		t.Errorf("Test case Failed %v, %v", response, "File Secret Title")
@@ -818,14 +917,18 @@ func TestSecretCreateFileSecretFlowErrorFileContent(t *testing.T) {
 	n := 5_000_001
 	fileContent := strings.Repeat("A", n)
 
-	secretTextDetails := entities.SecretFileDetails{
+	secretDetailsConfig := entities.SecretDetailsBaseConfig{
 		Title:       "Secret Title",
 		Description: "File Title Description",
-		FileName:    "textfile.txt",
-		FileContent: fileContent,
-		OwnerType:   "User",
-		OwnerId:     1,
-		Owners: []entities.OwnerDetails{
+	}
+
+	secretTextDetails := entities.SecretFileDetailsConfig30{
+		SecretDetailsBaseConfig: secretDetailsConfig,
+		FileName:                "textfile.txt",
+		FileContent:             fileContent,
+		OwnerType:               "User",
+		OwnerId:                 1,
+		Owners: []entities.OwnerDetailsOwnerId{
 			{
 				OwnerId: 1,
 				Owner:   "administrator",
@@ -877,14 +980,18 @@ func TestSecretCreateFileSecretFlowError(t *testing.T) {
 	authenticate.ApiUrl = *apiUrl
 	secretObj, _ := NewSecretObj(*authenticate, zapLogger, 4000)
 
-	secretTextDetails := entities.SecretFileDetails{
+	secretDetailsConfig := entities.SecretDetailsBaseConfig{
 		Title:       "Secret Title",
 		Description: "File Title Description",
-		FileName:    "textfile.txt",
-		FileContent: "Secret Content",
-		OwnerType:   "User",
-		OwnerId:     1,
-		Owners: []entities.OwnerDetails{
+	}
+
+	secretTextDetails := entities.SecretFileDetailsConfig30{
+		SecretDetailsBaseConfig: secretDetailsConfig,
+		FileName:                "textfile.txt",
+		FileContent:             "Secret Content",
+		OwnerType:               "User",
+		OwnerId:                 1,
+		Owners: []entities.OwnerDetailsOwnerId{
 			{
 				OwnerId: 1,
 				Owner:   "administrator",
@@ -939,14 +1046,17 @@ func TestSecretCreateBadInput(t *testing.T) {
 	authenticate.ApiUrl = *apiUrl
 	secretObj, _ := NewSecretObj(*authenticate, zapLogger, 4000)
 
-	secretTextDetails := entities.SecretCredentialDetails{
-		Title:       "",
+	secretDetailsConfig := entities.SecretDetailsBaseConfig{
 		Description: "Title Description",
-		Username:    "TestUserName",
-		Password:    constants.FakePassword,
-		OwnerType:   "User",
-		OwnerId:     1,
-		Owners: []entities.OwnerDetails{
+	}
+
+	secretTextDetails := entities.SecretCredentialDetailsConfig30{
+		SecretDetailsBaseConfig: secretDetailsConfig,
+		Username:                "TestUserName",
+		Password:                constants.FakePassword,
+		OwnerType:               "User",
+		OwnerId:                 1,
+		Owners: []entities.OwnerDetailsOwnerId{
 			{
 				OwnerId: 1,
 				Owner:   "administrator",
@@ -991,14 +1101,18 @@ func TestSecretCreateSecretFlowFolderNotFound(t *testing.T) {
 	authenticate.ApiUrl = *apiUrl
 	secretObj, _ := NewSecretObj(*authenticate, zapLogger, 4000)
 
-	secretTextDetails := entities.SecretTextDetails{
+	secretDetailsConfig := entities.SecretDetailsBaseConfig{
 		Title:       "Secret Title",
 		Description: "Title Description",
-		Text:        constants.FakePassword,
-		OwnerType:   "User",
-		OwnerId:     1,
-		FolderId:    uuid.New(),
-		Owners: []entities.OwnerDetails{
+	}
+
+	secretTextDetails := entities.SecretTextDetailsConfig30{
+		SecretDetailsBaseConfig: secretDetailsConfig,
+		Text:                    constants.FakePassword,
+		OwnerType:               "User",
+		OwnerId:                 1,
+		FolderId:                uuid.New(),
+		Owners: []entities.OwnerDetailsOwnerId{
 			{
 				OwnerId: 1,
 				Owner:   "administrator",
@@ -1043,14 +1157,18 @@ func TestSecretCreateSecretFlowEmptyFolderList(t *testing.T) {
 	authenticate.ApiUrl = *apiUrl
 	secretObj, _ := NewSecretObj(*authenticate, zapLogger, 4000)
 
-	secretTextDetails := entities.SecretTextDetails{
+	secretDetailsConfig := entities.SecretDetailsBaseConfig{
 		Title:       "Secret Title",
 		Description: "Title Description",
-		Text:        constants.FakePassword,
-		OwnerType:   "User",
-		OwnerId:     1,
-		FolderId:    uuid.New(),
-		Owners: []entities.OwnerDetails{
+	}
+
+	secretTextDetails := entities.SecretTextDetailsConfig30{
+		SecretDetailsBaseConfig: secretDetailsConfig,
+		Text:                    constants.FakePassword,
+		OwnerType:               "User",
+		OwnerId:                 1,
+		FolderId:                uuid.New(),
+		Owners: []entities.OwnerDetailsOwnerId{
 			{
 				OwnerId: 1,
 				Owner:   "administrator",

--- a/api/utils/httpclient.go
+++ b/api/utils/httpclient.go
@@ -230,7 +230,7 @@ func (client *HttpClientObj) HttpRequest(url string, method string, body bytes.B
 }
 
 // CreateMultipartRequest creates and sends multipart request.
-func (client *HttpClientObj) CreateMultiPartRequest(url, fileName string, metadata []byte, fileContent string) (io.ReadCloser, error) {
+func (client *HttpClientObj) CreateMultiPartRequest(url, fileName string, metadata []byte, fileContent string, apiVersion string) (io.ReadCloser, error) {
 
 	var requestBody bytes.Buffer
 
@@ -259,6 +259,7 @@ func (client *HttpClientObj) CreateMultiPartRequest(url, fileName string, metada
 	}
 
 	callSecretSafeAPIObj := &entities.CallSecretSafeAPIObj{
+		ApiVersion:  apiVersion,
 		Url:         url,
 		HttpMethod:  "POST",
 		Body:        requestBody,

--- a/api/utils/httpclient_test.go
+++ b/api/utils/httpclient_test.go
@@ -213,7 +213,7 @@ func TestCreateMultiPartRequest(t *testing.T) {
 	zapLogger := logging.NewZapLogger(logger)
 
 	httpClientObj, _ := GetHttpClient(30, false, "", "", zapLogger)
-	_, err := httpClientObj.CreateMultiPartRequest(server.URL+"/secrets/file", "file_name.txt", []byte("metadata"), "file_content")
+	_, err := httpClientObj.CreateMultiPartRequest(server.URL+"/secrets/file", "file_name.txt", []byte("metadata"), "file_content", constants.ApiVersion31)
 
 	if err != nil {
 		t.Errorf("Test case Failed: %v", err)


### PR DESCRIPTION
### Purpose of the PR
Add support for API version (3.0, 3.1) in create credential, text and file features.

### According to ticket
<!-- Jira url or ticket number -->
https://beyondtrust.atlassian.net/browse/BIPS-27413

### Summary of changes:

Add support API support for the next resources:

- passwordsafe_credential_secret
- passwordsafe_text_secret
- passwordsafe_file_secret

Update unit tests cases.
Update TestClient.go script.
Add needed entities to support versions (3.0/3.1)
Call CreateManagedSystem method in TestClient.go test script.
Fix issue in get secret by path datasource: https://beyondtrust.atlassian.net/browse/BIPS-27415
Set default value for timeout attribute in create managed system resources: https://beyondtrust.atlassian.net/browse/BIPS-27438
