### PR TITLE
fix: ContactEmail default value for creating managed system by workgroup is invalid

### DIFF
--- a/api/entities/entities.go
+++ b/api/entities/entities.go
@@ -369,7 +369,7 @@ type ManagedSystemResponseCreate struct {
 type ManagedSystemsByWorkGroupIdDetailsBaseConfig struct {
 	EntityTypeID                       int    `json:",omitempty" validate:"required"`
 	HostName                           string `json:",omitempty" validate:"required,max=128"`
-	IPAddress                          string `json:",omitempty" validate:"max=46"`
+	IPAddress                          string `json:",omitempty" validate:"required,ip,max=46"`
 	DnsName                            string `json:",omitempty" validate:"max=225"`
 	InstanceName                       string `json:",omitempty" validate:"required_if=IsDefaultInstance true,max=100"`
 	IsDefaultInstance                  bool   `json:",omitempty"`

--- a/api/entities/entities.go
+++ b/api/entities/entities.go
@@ -401,7 +401,7 @@ type ManagedSystemsByWorkGroupIdDetailsBaseConfig struct {
 	ChangeFrequencyType                string `json:",omitempty" validate:"oneof=first last xdays"`
 	ChangeFrequencyDays                int    `json:",omitempty" validate:"required_if=ChangeFrequencyType xdays"`
 	ChangeTime                         string `json:",omitempty" validate:"datetime=15:04"`
-	AccessURL                          string `json:",omitempty" validate:"required,url"`
+	AccessURL                          string `json:",omitempty"`
 }
 
 type ManagedSystemsByWorkGroupIdDetailsConfig30 struct {

--- a/api/entities/entities.go
+++ b/api/entities/entities.go
@@ -369,7 +369,7 @@ type ManagedSystemResponseCreate struct {
 type ManagedSystemsByWorkGroupIdDetailsBaseConfig struct {
 	EntityTypeID                       int    `json:",omitempty" validate:"required"`
 	HostName                           string `json:",omitempty" validate:"required,max=128"`
-	IPAddress                          string `json:",omitempty" validate:"required,ip,max=46"`
+	IPAddress                          string `json:",omitempty" validate:"max=46"`
 	DnsName                            string `json:",omitempty" validate:"max=225"`
 	InstanceName                       string `json:",omitempty" validate:"required_if=IsDefaultInstance true,max=100"`
 	IsDefaultInstance                  bool   `json:",omitempty"`
@@ -378,7 +378,7 @@ type ManagedSystemsByWorkGroupIdDetailsBaseConfig struct {
 	UseSSL                             bool   `json:",omitempty"`
 	PlatformID                         int    `json:",omitempty" validate:"required"`
 	NetBiosName                        string `json:",omitempty" validate:"max=15"`
-	ContactEmail                       string `json:",omitempty" validate:"email,max=1000"`
+	ContactEmail                       string `json:",omitempty" validate:"max=1000"`
 	Description                        string `json:",omitempty" validate:"max=255"`
 	Port                               int    `json:",omitempty"`
 	Timeout                            int    `json:",omitempty"`

--- a/api/managed_systems/managed_systems_test.go
+++ b/api/managed_systems/managed_systems_test.go
@@ -376,7 +376,7 @@ func TestCreateManagedSystemByWorkGroupIdFlowEmptyWorkGroupId(t *testing.T) {
 
 }
 
-func TestCreateManagedSystemByWorkGroupIdEmptyEmail(t *testing.T) {
+func TestCreateManagedSystemByWorkGroupIdEmptyEmailAndAccesUrl(t *testing.T) {
 
 	InitializeGlobalConfig()
 
@@ -420,7 +420,7 @@ func TestCreateManagedSystemByWorkGroupIdEmptyEmail(t *testing.T) {
 			ISAReleaseDuration:  130,
 			ChangeFrequencyType: "first",
 			ChangeTime:          "00:00",
-			AccessURL:           "https://example.com",
+			AccessURL:           "",
 		},
 	}
 


### PR DESCRIPTION
### Purpose of the PR
ContactEmail default value for creating managed system by workgroup is invalid.

### According to ticket
<!-- Jira url or ticket number -->
https://beyondtrust.atlassian.net/browse/BIPS-27538

### Summary of changes:

- Remove validation for email field as it is not mandatory.
- Remove validation for access URL field as it is not mandatory.
- Create unit test  for above changes.