### PR TITLE
feat: BIPS-32651 add API v3.2 support for creating secrets

### DIFF
--- a/api/constants/constants.go
+++ b/api/constants/constants.go
@@ -11,6 +11,7 @@ var (
 	FakeApiKey         = os.Getenv("PASSWORD_SAFE_FAKE_API_KEY")
 	FakeClientSecret   = os.Getenv("PASSWORD_SAFE_FAKE_CLIENT_SECRET")
 	ApiVersion31       = "3.1"
+	ApiVersion32       = "3.2"
 	Fakecertificate    = os.Getenv("PASSWORD_SAFE_FAKE_CERTIFICATE")
 	FakecertificateKey = os.Getenv("PASSWORD_SAFE_FAKE_CERTIFICATE_KEY")
 	FakePassword       = os.Getenv("PASSWORD_SAFE_FAKE_PASSWORD")

--- a/api/entities/entities.go
+++ b/api/entities/entities.go
@@ -112,11 +112,21 @@ type FolderResponse struct {
 	Description string
 }
 
+// SecretListResponse is the v3.2+ wrapper shape returned by GET secrets-safe/secrets
+// (and the path-lookup variant). v3.0/v3.1 return a bare array instead — the library
+// normalizes both shapes through decodeSecretListResponse.
+type SecretListResponse struct {
+	TotalCount int      `json:"TotalCount"`
+	Data       []Secret `json:"Data"`
+}
+
 type CreateSecretResponse struct {
 	Id          string
 	Title       string
 	Description string
 	FolderId    string
+	// SecretValueModifiedOn is populated by API v3.2+ responses; empty on v3.0/v3.1.
+	SecretValueModifiedOn string `json:",omitempty"`
 }
 
 type SecretCredentialDetailsConfig30 struct {
@@ -130,6 +140,16 @@ type SecretCredentialDetailsConfig30 struct {
 }
 
 type SecretCredentialDetailsConfig31 struct {
+	SecretDetailsBaseConfig
+	Username       string                `json:",omitempty" validate:"required"`
+	Password       string                `json:",omitempty" validate:"max=256,required_without=PasswordRuleID"`
+	Owners         []OwnerDetailsGroupId `json:",omitempty" validate:"required"`
+	PasswordRuleID int                   `json:",omitempty" validate:"omitempty"`
+}
+
+// SecretCredentialDetailsConfig32 is the v3.2 credential request payload.
+// Per the API spec the request shape is identical to v3.1; v3.2 only enriches the response.
+type SecretCredentialDetailsConfig32 struct {
 	SecretDetailsBaseConfig
 	Username       string                `json:",omitempty" validate:"required"`
 	Password       string                `json:",omitempty" validate:"max=256,required_without=PasswordRuleID"`
@@ -160,6 +180,15 @@ type SecretTextDetailsConfig31 struct {
 	FolderId uuid.UUID             `json:",omitempty" validate:"omitempty"`
 }
 
+// SecretTextDetailsConfig32 is the v3.2 text-secret request payload.
+// Per the API spec the request shape is identical to v3.1; v3.2 only enriches the response.
+type SecretTextDetailsConfig32 struct {
+	SecretDetailsBaseConfig
+	Text     string                `json:",omitempty" validate:"required,max=4096"`
+	Owners   []OwnerDetailsGroupId `json:",omitempty" validate:"required"`
+	FolderId uuid.UUID             `json:",omitempty" validate:"omitempty"`
+}
+
 type SecretFileDetailsConfig30 struct {
 	SecretDetailsBaseConfig
 	OwnerId     int                   `json:",omitempty" validate:"required_if=OwnerType Group"`
@@ -174,6 +203,50 @@ type SecretFileDetailsConfig31 struct {
 	Owners      []OwnerDetailsGroupId `json:",omitempty" validate:"required"`
 	FileName    string                `json:",omitempty" validate:"required,max=256"`
 	FileContent string                `json:",omitempty" validate:"required,max=5000000"`
+}
+
+// SecretFileDetailsConfig32 is the v3.2 file-secret request payload.
+// Per the API spec the request shape is identical to v3.1; v3.2 only enriches the response.
+type SecretFileDetailsConfig32 struct {
+	SecretDetailsBaseConfig
+	Owners      []OwnerDetailsGroupId `json:",omitempty" validate:"required"`
+	FileName    string                `json:",omitempty" validate:"required,max=256"`
+	FileContent string                `json:",omitempty" validate:"required,max=5000000"`
+}
+
+// SecretCredentialInput is a version-neutral input for creating credential secrets.
+// CreateSecretFlow selects Config30 or Config31 based on the authenticated API version.
+type SecretCredentialInput struct {
+	SecretDetailsBaseConfig
+	Username        string
+	Password        string
+	OwnerId         int
+	OwnerType       string
+	OwnersByOwnerId []OwnerDetailsOwnerId
+	OwnersByGroupId []OwnerDetailsGroupId
+}
+
+// SecretTextInput is a version-neutral input for creating text secrets.
+// CreateSecretFlow selects Config30 or Config31 based on the authenticated API version.
+type SecretTextInput struct {
+	SecretDetailsBaseConfig
+	Text            string
+	OwnerId         int
+	OwnerType       string
+	OwnersByOwnerId []OwnerDetailsOwnerId
+	OwnersByGroupId []OwnerDetailsGroupId
+}
+
+// SecretFileInput is a version-neutral input for creating file secrets.
+// CreateSecretFlow selects Config30 or Config31 based on the authenticated API version.
+type SecretFileInput struct {
+	SecretDetailsBaseConfig
+	FileName        string
+	FileContent     string
+	OwnerId         int
+	OwnerType       string
+	OwnersByOwnerId []OwnerDetailsOwnerId
+	OwnersByGroupId []OwnerDetailsGroupId
 }
 
 type OwnerDetailsOwnerId struct {

--- a/api/secrets/secrets.go
+++ b/api/secrets/secrets.go
@@ -200,8 +200,7 @@ func (secretObj *SecretObj) SecretGetSecretByPath(secretPath string, secretTitle
 		return entities.Secret{}, err
 	}
 
-	var SecretObjectList []entities.Secret
-	err = json.Unmarshal([]byte(bodyBytes), &SecretObjectList)
+	SecretObjectList, err := decodeSecretListResponse(bodyBytes)
 	if err != nil {
 		err = errors.New(err.Error() + ", Ensure Password Safe version is 23.1 or greater.")
 		return entities.Secret{}, err
@@ -264,13 +263,33 @@ func (secretObj *SecretObj) SecretGetFileSecret(secretId string, endpointPath st
 
 }
 
-// CreateSecretCredentialFlow is responsible for creating secrets in Password Safe.
+// CreateSecretFlow is responsible for creating secrets in Password Safe.
+// secretDetails accepts either a version-neutral input (SecretCredentialInput,
+// SecretTextInput, SecretFileInput) — in which case the matching Config30/Config31
+// is selected here based on the authenticated API version — or a Config30/Config31
+// directly, which is passed through unchanged for backward compatibility.
 func (secretObj *SecretObj) CreateSecretFlow(folderTarget string, secretDetails interface{}) (entities.CreateSecretResponse, error) {
 
 	var folder *entities.FolderResponse
 	var createResponse entities.CreateSecretResponse
+	var err error
 
-	err := utils.ValidateData(secretDetails)
+	// Translate version-neutral inputs into the Config30/Config31 the API expects;
+	// callers passing Config30/Config31 directly fall through unchanged.
+	switch in := secretDetails.(type) {
+	case entities.SecretCredentialInput:
+		secretDetails, err = buildCredentialSecretConfig(in, secretObj.authenticationObj.ApiVersion)
+	case entities.SecretTextInput:
+		secretDetails, err = buildTextSecretConfig(in, secretObj.authenticationObj.ApiVersion)
+	case entities.SecretFileInput:
+		secretDetails, err = buildFileSecretConfig(in, secretObj.authenticationObj.ApiVersion)
+	}
+
+	if err != nil {
+		return createResponse, err
+	}
+
+	err = utils.ValidateData(secretDetails)
 
 	if err != nil {
 		return createResponse, err
@@ -302,6 +321,109 @@ func (secretObj *SecretObj) CreateSecretFlow(folderTarget string, secretDetails 
 	return createResponse, nil
 }
 
+// buildCredentialSecretConfig selects the credential secret config struct matching apiVersion.
+func buildCredentialSecretConfig(in entities.SecretCredentialInput, apiVersion string) (interface{}, error) {
+	switch apiVersion {
+	case "3.0":
+		return entities.SecretCredentialDetailsConfig30{
+			SecretDetailsBaseConfig: in.SecretDetailsBaseConfig,
+			Username:                in.Username,
+			Password:                in.Password,
+			OwnerId:                 in.OwnerId,
+			OwnerType:               in.OwnerType,
+			Owners:                  in.OwnersByOwnerId,
+		}, nil
+	case "3.1":
+		return entities.SecretCredentialDetailsConfig31{
+			SecretDetailsBaseConfig: in.SecretDetailsBaseConfig,
+			Username:                in.Username,
+			Password:                in.Password,
+			Owners:                  in.OwnersByGroupId,
+		}, nil
+	case "3.2":
+		return entities.SecretCredentialDetailsConfig32{
+			SecretDetailsBaseConfig: in.SecretDetailsBaseConfig,
+			Username:                in.Username,
+			Password:                in.Password,
+			Owners:                  in.OwnersByGroupId,
+		}, nil
+	}
+	return nil, fmt.Errorf("unsupported API version: %v", apiVersion)
+}
+
+// buildTextSecretConfig selects the text secret config struct matching apiVersion.
+func buildTextSecretConfig(in entities.SecretTextInput, apiVersion string) (interface{}, error) {
+	switch apiVersion {
+	case "3.0":
+		return entities.SecretTextDetailsConfig30{
+			SecretDetailsBaseConfig: in.SecretDetailsBaseConfig,
+			Text:                    in.Text,
+			OwnerId:                 in.OwnerId,
+			OwnerType:               in.OwnerType,
+			Owners:                  in.OwnersByOwnerId,
+		}, nil
+	case "3.1":
+		return entities.SecretTextDetailsConfig31{
+			SecretDetailsBaseConfig: in.SecretDetailsBaseConfig,
+			Text:                    in.Text,
+			Owners:                  in.OwnersByGroupId,
+		}, nil
+	case "3.2":
+		return entities.SecretTextDetailsConfig32{
+			SecretDetailsBaseConfig: in.SecretDetailsBaseConfig,
+			Text:                    in.Text,
+			Owners:                  in.OwnersByGroupId,
+		}, nil
+	}
+	return nil, fmt.Errorf("unsupported API version: %v", apiVersion)
+}
+
+// buildFileSecretConfig selects the file secret config struct matching apiVersion.
+func buildFileSecretConfig(in entities.SecretFileInput, apiVersion string) (interface{}, error) {
+	switch apiVersion {
+	case "3.0":
+		return entities.SecretFileDetailsConfig30{
+			SecretDetailsBaseConfig: in.SecretDetailsBaseConfig,
+			FileName:                in.FileName,
+			FileContent:             in.FileContent,
+			OwnerId:                 in.OwnerId,
+			OwnerType:               in.OwnerType,
+			Owners:                  in.OwnersByOwnerId,
+		}, nil
+	case "3.1":
+		return entities.SecretFileDetailsConfig31{
+			SecretDetailsBaseConfig: in.SecretDetailsBaseConfig,
+			FileName:                in.FileName,
+			FileContent:             in.FileContent,
+			Owners:                  in.OwnersByGroupId,
+		}, nil
+	case "3.2":
+		return entities.SecretFileDetailsConfig32{
+			SecretDetailsBaseConfig: in.SecretDetailsBaseConfig,
+			FileName:                in.FileName,
+			FileContent:             in.FileContent,
+			Owners:                  in.OwnersByGroupId,
+		}, nil
+	}
+	return nil, fmt.Errorf("unsupported API version: %v", apiVersion)
+}
+
+// decodeSecretListResponse normalizes the secrets-safe/secrets response shape across API versions.
+// v3.0/v3.1 return a bare JSON array; v3.2+ wraps it as {"TotalCount": N, "Data": [...]}.
+// Try the wrapper first; if the body is the bare array shape, the struct unmarshal fails
+// and we fall through to decode it as a list. Mirrors the TS idiom:
+//
+//	Array.isArray(data) ? data : data.Data
+func decodeSecretListResponse(body []byte) ([]entities.Secret, error) {
+	var wrapped entities.SecretListResponse
+	if err := json.Unmarshal(body, &wrapped); err == nil {
+		return wrapped.Data, nil
+	}
+	var list []entities.Secret
+	err := json.Unmarshal(body, &list)
+	return list, err
+}
+
 // SecretCreateFileSecret create a secret of type file.
 func (secretObj *SecretObj) SecretCreateFileSecret(SecretCreateSecretUrl string, payload string, secretDetails interface{}) (entities.CreateSecretResponse, error) {
 
@@ -315,6 +437,9 @@ func (secretObj *SecretObj) SecretCreateFileSecret(SecretCreateSecretUrl string,
 		fileName = fileSecret.FileName
 		fileContent = fileSecret.FileContent
 	case entities.SecretFileDetailsConfig31:
+		fileName = fileSecret.FileName
+		fileContent = fileSecret.FileContent
+	case entities.SecretFileDetailsConfig32:
 		fileName = fileSecret.FileName
 		fileContent = fileSecret.FileContent
 	}
@@ -427,13 +552,19 @@ func (secretObj *SecretObj) GetPathToCreateSecret(secretDetails interface{}) str
 		path = "secrets"
 	case entities.SecretCredentialDetailsConfig31:
 		path = "secrets"
+	case entities.SecretCredentialDetailsConfig32:
+		path = "secrets"
 	case entities.SecretTextDetailsConfig30:
 		path = "secrets/text"
 	case entities.SecretTextDetailsConfig31:
 		path = "secrets/text"
+	case entities.SecretTextDetailsConfig32:
+		path = "secrets/text"
 	case entities.SecretFileDetailsConfig30:
 		path = "secrets/file"
 	case entities.SecretFileDetailsConfig31:
+		path = "secrets/file"
+	case entities.SecretFileDetailsConfig32:
 		path = "secrets/file"
 	}
 	return path
@@ -734,9 +865,9 @@ func (secretObj *SecretObj) SearchSecretByTitle(endpointPath string, title strin
 		return secretResponse, err
 	}
 
-	err = json.Unmarshal(response, &secretResponse)
+	secretResponse, err = decodeSecretListResponse(response)
 	if err != nil {
-		return secretResponse, err
+		return nil, err
 	}
 
 	return secretResponse, nil

--- a/api/secrets/secrets_test.go
+++ b/api/secrets/secrets_test.go
@@ -1845,3 +1845,391 @@ func TestSearchSecretByTitleFlowSecretNotFound(t *testing.T) {
 		t.Error("Test case Failed: Expected error for 404 response")
 	}
 }
+
+// TestBuildCredentialSecretConfig covers the per-version dispatch in the credential build helper.
+func TestBuildCredentialSecretConfig(t *testing.T) {
+	in := entities.SecretCredentialInput{
+		SecretDetailsBaseConfig: entities.SecretDetailsBaseConfig{Title: "T", Description: "D", Notes: "N"},
+		Username:                "u",
+		Password:                "p",
+		OwnerId:                 1,
+		OwnerType:               "User",
+		OwnersByOwnerId:         []entities.OwnerDetailsOwnerId{{OwnerId: 1, Owner: "a", Email: "x@y"}},
+		OwnersByGroupId:         []entities.OwnerDetailsGroupId{{GroupId: 7, UserId: 1, Name: "a", Email: "x@y"}},
+	}
+
+	t.Run("v3.0 returns Config30 with OwnersByOwnerId", func(t *testing.T) {
+		got, err := buildCredentialSecretConfig(in, "3.0")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		cfg, ok := got.(entities.SecretCredentialDetailsConfig30)
+		if !ok {
+			t.Fatalf("expected SecretCredentialDetailsConfig30, got %T", got)
+		}
+		if cfg.Username != "u" || cfg.Password != "p" || cfg.OwnerId != 1 || cfg.OwnerType != "User" {
+			t.Errorf("fields not mapped: %+v", cfg)
+		}
+		if len(cfg.Owners) != 1 || cfg.Owners[0].Owner != "a" {
+			t.Errorf("expected OwnersByOwnerId, got %+v", cfg.Owners)
+		}
+	})
+
+	t.Run("v3.1 returns Config31 with OwnersByGroupId", func(t *testing.T) {
+		got, err := buildCredentialSecretConfig(in, "3.1")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		cfg, ok := got.(entities.SecretCredentialDetailsConfig31)
+		if !ok {
+			t.Fatalf("expected SecretCredentialDetailsConfig31, got %T", got)
+		}
+		if cfg.Username != "u" || cfg.Password != "p" {
+			t.Errorf("fields not mapped: %+v", cfg)
+		}
+		if len(cfg.Owners) != 1 || cfg.Owners[0].GroupId != 7 {
+			t.Errorf("expected OwnersByGroupId, got %+v", cfg.Owners)
+		}
+	})
+
+	t.Run("v3.2 returns Config32 with OwnersByGroupId", func(t *testing.T) {
+		got, err := buildCredentialSecretConfig(in, "3.2")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		cfg, ok := got.(entities.SecretCredentialDetailsConfig32)
+		if !ok {
+			t.Fatalf("expected SecretCredentialDetailsConfig32, got %T", got)
+		}
+		if cfg.Username != "u" || cfg.Password != "p" {
+			t.Errorf("fields not mapped: %+v", cfg)
+		}
+		if len(cfg.Owners) != 1 || cfg.Owners[0].GroupId != 7 {
+			t.Errorf("expected OwnersByGroupId, got %+v", cfg.Owners)
+		}
+	})
+
+	t.Run("unsupported version returns error", func(t *testing.T) {
+		_, err := buildCredentialSecretConfig(in, "9.9")
+		if err == nil || !strings.Contains(err.Error(), "unsupported API version") {
+			t.Errorf("expected unsupported API version error, got %v", err)
+		}
+	})
+}
+
+// TestBuildTextSecretConfig covers the per-version dispatch in the text build helper.
+func TestBuildTextSecretConfig(t *testing.T) {
+	in := entities.SecretTextInput{
+		SecretDetailsBaseConfig: entities.SecretDetailsBaseConfig{Title: "T"},
+		Text:                    "secret-text",
+		OwnerId:                 1,
+		OwnerType:               "User",
+		OwnersByOwnerId:         []entities.OwnerDetailsOwnerId{{OwnerId: 1, Owner: "a", Email: "x@y"}},
+		OwnersByGroupId:         []entities.OwnerDetailsGroupId{{GroupId: 7, UserId: 1, Name: "a", Email: "x@y"}},
+	}
+
+	t.Run("v3.0 returns Config30", func(t *testing.T) {
+		got, err := buildTextSecretConfig(in, "3.0")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		cfg, ok := got.(entities.SecretTextDetailsConfig30)
+		if !ok {
+			t.Fatalf("expected SecretTextDetailsConfig30, got %T", got)
+		}
+		if cfg.Text != "secret-text" || cfg.OwnerId != 1 || cfg.OwnerType != "User" {
+			t.Errorf("fields not mapped: %+v", cfg)
+		}
+	})
+
+	t.Run("v3.1 returns Config31", func(t *testing.T) {
+		got, err := buildTextSecretConfig(in, "3.1")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if _, ok := got.(entities.SecretTextDetailsConfig31); !ok {
+			t.Fatalf("expected SecretTextDetailsConfig31, got %T", got)
+		}
+	})
+
+	t.Run("v3.2 returns Config32", func(t *testing.T) {
+		got, err := buildTextSecretConfig(in, "3.2")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if _, ok := got.(entities.SecretTextDetailsConfig32); !ok {
+			t.Fatalf("expected SecretTextDetailsConfig32, got %T", got)
+		}
+	})
+
+	t.Run("unsupported version returns error", func(t *testing.T) {
+		_, err := buildTextSecretConfig(in, "9.9")
+		if err == nil || !strings.Contains(err.Error(), "unsupported API version") {
+			t.Errorf("expected unsupported API version error, got %v", err)
+		}
+	})
+}
+
+// TestBuildFileSecretConfig covers the per-version dispatch in the file build helper.
+func TestBuildFileSecretConfig(t *testing.T) {
+	in := entities.SecretFileInput{
+		SecretDetailsBaseConfig: entities.SecretDetailsBaseConfig{Title: "T"},
+		FileName:                "config.json",
+		FileContent:             "file-content",
+		OwnerId:                 1,
+		OwnerType:               "User",
+		OwnersByOwnerId:         []entities.OwnerDetailsOwnerId{{OwnerId: 1, Owner: "a", Email: "x@y"}},
+		OwnersByGroupId:         []entities.OwnerDetailsGroupId{{GroupId: 7, UserId: 1, Name: "a", Email: "x@y"}},
+	}
+
+	t.Run("v3.0 returns Config30", func(t *testing.T) {
+		got, err := buildFileSecretConfig(in, "3.0")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		cfg, ok := got.(entities.SecretFileDetailsConfig30)
+		if !ok {
+			t.Fatalf("expected SecretFileDetailsConfig30, got %T", got)
+		}
+		if cfg.FileName != "config.json" || cfg.FileContent != "file-content" {
+			t.Errorf("fields not mapped: %+v", cfg)
+		}
+	})
+
+	t.Run("v3.1 returns Config31", func(t *testing.T) {
+		got, err := buildFileSecretConfig(in, "3.1")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if _, ok := got.(entities.SecretFileDetailsConfig31); !ok {
+			t.Fatalf("expected SecretFileDetailsConfig31, got %T", got)
+		}
+	})
+
+	t.Run("v3.2 returns Config32", func(t *testing.T) {
+		got, err := buildFileSecretConfig(in, "3.2")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if _, ok := got.(entities.SecretFileDetailsConfig32); !ok {
+			t.Fatalf("expected SecretFileDetailsConfig32, got %T", got)
+		}
+	})
+
+	t.Run("unsupported version returns error", func(t *testing.T) {
+		_, err := buildFileSecretConfig(in, "9.9")
+		if err == nil || !strings.Contains(err.Error(), "unsupported API version") {
+			t.Errorf("expected unsupported API version error, got %v", err)
+		}
+	})
+}
+
+// TestDecodeSecretListResponse covers normalization of v3.0/v3.1 array and v3.2 wrapper shapes.
+func TestDecodeSecretListResponse(t *testing.T) {
+	cases := []struct {
+		name      string
+		body      string
+		wantLen   int
+		wantTitle string
+		wantErr   bool
+	}{
+		{
+			name:      "v3.0/v3.1 bare array with one item",
+			body:      `[{"Id":"id-1","Title":"T1"}]`,
+			wantLen:   1,
+			wantTitle: "T1",
+		},
+		{
+			name:    "empty array",
+			body:    `[]`,
+			wantLen: 0,
+		},
+		{
+			name:      "v3.2 wrapped object with one item",
+			body:      `{"TotalCount":1,"Data":[{"Id":"id-1","Title":"T2"}]}`,
+			wantLen:   1,
+			wantTitle: "T2",
+		},
+		{
+			name:    "v3.2 wrapped object with empty Data",
+			body:    `{"TotalCount":0,"Data":[]}`,
+			wantLen: 0,
+		},
+		{
+			name:    "leading whitespace before array still parses",
+			body:    "   \n[{\"Id\":\"id-1\",\"Title\":\"T1\"}]",
+			wantLen: 1,
+		},
+		{
+			name:    "invalid JSON returns error",
+			body:    `not json`,
+			wantErr: true,
+		},
+	}
+	for _, c := range cases {
+		c := c
+		t.Run(c.name, func(t *testing.T) {
+			got, err := decodeSecretListResponse([]byte(c.body))
+			if c.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if len(got) != c.wantLen {
+				t.Fatalf("got %d items, want %d", len(got), c.wantLen)
+			}
+			if c.wantTitle != "" && got[0].Title != c.wantTitle {
+				t.Errorf("got Title=%q, want %q", got[0].Title, c.wantTitle)
+			}
+		})
+	}
+}
+
+// TestCreateSecretFlowWithNeutralInputs verifies CreateSecretFlow accepts the new
+// version-neutral inputs and dispatches correctly across v3.0/v3.1/v3.2.
+func TestCreateSecretFlowWithNeutralInputs(t *testing.T) {
+	InitializeGlobalConfig()
+
+	var authenticate, _ = authentication.Authenticate(*authParams)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/secrets-safe/folders/":
+			_, _ = w.Write([]byte(`[{"Id":"folder-id","Name":"folder1"}]`))
+		case "/secrets-safe/folders/folder-id/secrets",
+			"/secrets-safe/folders/folder-id/secrets/text",
+			"/secrets-safe/folders/folder-id/secrets/file":
+			_, _ = w.Write([]byte(`{"Id":"new-secret-id","Title":"T","Description":"D"}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	apiUrl, _ := url.Parse(server.URL + "/")
+	authenticate.ApiUrl = *apiUrl
+	secretObj, _ := NewSecretObj(*authenticate, zapLogger, 4000, true)
+
+	base := entities.SecretDetailsBaseConfig{Title: "T", Description: "D"}
+	ownerById := []entities.OwnerDetailsOwnerId{{OwnerId: 1, Owner: "a", Email: "x@y"}}
+	ownerByGroup := []entities.OwnerDetailsGroupId{{GroupId: 7, UserId: 1, Name: "a", Email: "x@y"}}
+
+	for _, v := range []string{"3.0", "3.1", "3.2"} {
+		v := v
+		secretObj.authenticationObj.ApiVersion = v
+
+		t.Run("credential v"+v, func(t *testing.T) {
+			in := entities.SecretCredentialInput{
+				SecretDetailsBaseConfig: base,
+				Username:                "u",
+				Password:                "p",
+				OwnerId:                 1,
+				OwnerType:               "User",
+				OwnersByOwnerId:         ownerById,
+				OwnersByGroupId:         ownerByGroup,
+			}
+			resp, err := secretObj.CreateSecretFlow("folder1", in)
+			if err != nil {
+				t.Fatalf("CreateSecretFlow error for v%s: %v", v, err)
+			}
+			if resp.Id != "new-secret-id" {
+				t.Errorf("expected new-secret-id, got %+v", resp)
+			}
+		})
+
+		t.Run("text v"+v, func(t *testing.T) {
+			in := entities.SecretTextInput{
+				SecretDetailsBaseConfig: base,
+				Text:                    "secret-text",
+				OwnerId:                 1,
+				OwnerType:               "User",
+				OwnersByOwnerId:         ownerById,
+				OwnersByGroupId:         ownerByGroup,
+			}
+			resp, err := secretObj.CreateSecretFlow("folder1", in)
+			if err != nil {
+				t.Fatalf("CreateSecretFlow error for v%s: %v", v, err)
+			}
+			if resp.Id != "new-secret-id" {
+				t.Errorf("expected new-secret-id, got %+v", resp)
+			}
+		})
+	}
+}
+
+// TestCreateSecretFlowUnsupportedVersionRejected verifies an unsupported API version
+// surfaces the centralized error.
+func TestCreateSecretFlowUnsupportedVersionRejected(t *testing.T) {
+	InitializeGlobalConfig()
+
+	var authenticate, _ = authentication.Authenticate(*authParams)
+	secretObj, _ := NewSecretObj(*authenticate, zapLogger, 4000, true)
+	secretObj.authenticationObj.ApiVersion = "9.9"
+
+	in := entities.SecretCredentialInput{
+		SecretDetailsBaseConfig: entities.SecretDetailsBaseConfig{Title: "T"},
+		Username:                "u",
+		Password:                "p",
+	}
+	_, err := secretObj.CreateSecretFlow("folder1", in)
+	if err == nil || !strings.Contains(err.Error(), "unsupported API version") {
+		t.Fatalf("expected unsupported API version error, got %v", err)
+	}
+}
+
+// TestSearchSecretByTitleFlowWithV32WrappedResponse verifies decodeSecretListResponse
+// is wired into SearchSecretByTitle and unwraps the v3.2 envelope transparently.
+func TestSearchSecretByTitleFlowWithV32WrappedResponse(t *testing.T) {
+	InitializeGlobalConfig()
+
+	var authenticate, _ = authentication.Authenticate(*authParams)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, err := w.Write([]byte(`{"TotalCount":1,"Data":[{"Password":"secret_password","Id":"9152f5b6-07d6-4955-175a-08db047219ce","Title":"secret_title"}]}`))
+		if err != nil {
+			t.Error("Test case Failed")
+		}
+	}))
+	defer server.Close()
+
+	apiUrl, _ := url.Parse(server.URL + "/")
+	authenticate.ApiUrl = *apiUrl
+	secretObj, _ := NewSecretObj(*authenticate, zapLogger, 4000, true)
+
+	response, err := secretObj.SearchSecretByTitleFlow("secret_title")
+	if err != nil {
+		t.Fatalf("Test case Failed: %v", err)
+	}
+	if response.Id != "9152f5b6-07d6-4955-175a-08db047219ce" || response.Title != "secret_title" {
+		t.Errorf("Test case Failed: got %+v", response)
+	}
+}
+
+// TestSecretGetSecretByPathWithV32WrappedResponse verifies the path-lookup variant
+// also accepts the v3.2 wrapped response.
+func TestSecretGetSecretByPathWithV32WrappedResponse(t *testing.T) {
+	InitializeGlobalConfig()
+
+	var authenticate, _ = authentication.Authenticate(*authParams)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, err := w.Write([]byte(`{"TotalCount":1,"Data":[{"SecretType":"TEXT","Password":"secret_password","Id":"id-1","Title":"fake_title"}]}`))
+		if err != nil {
+			t.Error("Test case Failed")
+		}
+	}))
+	defer server.Close()
+
+	apiUrl, _ := url.Parse(server.URL + "/")
+	authenticate.ApiUrl = *apiUrl
+	secretObj, _ := NewSecretObj(*authenticate, zapLogger, 4000, true)
+
+	response, err := secretObj.SecretGetSecretByPath("path1/path2/", "fake_title", "/", "secrets-safe/secrets")
+	if err != nil {
+		t.Fatalf("Test case Failed: %v", err)
+	}
+	if response.Id != "id-1" || response.Title != "fake_title" {
+		t.Errorf("Test case Failed: got %+v", response)
+	}
+}


### PR DESCRIPTION
> This PR was generated by Claude Code on 2026-05-04 on behalf of Felipe Hernandez.

## Purpose of the PR

- Add Password Safe API v3.2 support for creating credential, text, and file secrets across integrations

## Linked JIRA issue(s)

- [BIPS-32651](https://beyondtrust.atlassian.net/browse/BIPS-32651)

## Summary of changes

### `api/constants/constants.go`
- Added exported constant `ApiVersion32 = "3.2"` alongside the existing `ApiVersion31`.

### `api/entities/entities.go`
- Added `SecretListResponse` struct (`TotalCount int`, `Data []Secret`) to model the v3.2+ paginated wrapper returned by `GET secrets-safe/secrets`; v3.0/v3.1 return a bare array and are normalized by `decodeSecretListResponse`.
- Added `SecretValueModifiedOn` field (`omitempty`) to `CreateSecretResponse` to capture the extra field populated by API v3.2+ responses.
- Added three new v3.2 request-payload structs:
  - `SecretCredentialDetailsConfig32` — credential secret (username/password + group-based owners)
  - `SecretTextDetailsConfig32` — text secret (text + group-based owners)
  - `SecretFileDetailsConfig32` — file secret (fileName/fileContent + group-based owners)
  - All three mirror the v3.1 request shapes; v3.2 only enriches the response.
- Added three version-neutral input structs intended for callers who do not want to hard-code an API version:
  - `SecretCredentialInput` — carries both `OwnersByOwnerId` (v3.0) and `OwnersByGroupId` (v3.1/v3.2) fields
  - `SecretTextInput` — same pattern for text secrets
  - `SecretFileInput` — same pattern for file secrets

### `api/secrets/secrets.go`
- Added private helper `decodeSecretListResponse(body []byte) ([]Secret, error)` that normalizes the API response shape: tries to unmarshal as `SecretListResponse` (v3.2+ wrapper) first, then falls back to a bare array (v3.0/v3.1). Used by both `SecretGetSecretByPath` and `SearchSecretByTitle`, replacing per-site `json.Unmarshal` calls.
- Added private builders `buildCredentialSecretConfig`, `buildTextSecretConfig`, `buildFileSecretConfig` that switch on `apiVersion` ("3.0", "3.1", "3.2") and return the appropriate Config struct, returning an error for unsupported versions.
- Extended `CreateSecretFlow` with a type-switch at the top: if the caller passes a `SecretCredentialInput`, `SecretTextInput`, or `SecretFileInput`, the flow now resolves it to the matching versioned Config struct before validation. Callers passing Config structs directly continue to work unchanged (backward compatible).
- Extended `GetPathToCreateSecret` with cases for `SecretCredentialDetailsConfig32` (`secrets`), `SecretTextDetailsConfig32` (`secrets/text`), and `SecretFileDetailsConfig32` (`secrets/file`).
- Extended `SecretCreateFileSecret` with a case for `SecretFileDetailsConfig32` to extract `FileName` and `FileContent` for multipart upload.

## Checklist

### Release

- [ ]  Priority release required due to Hot fix / Escalation / Critical bug
- [x]  Priority release not required (can be released later with other stories or bugs fixes)

### Testing

- [ ] dev
- [ ] automation (required for feature branch merges and significant changes)
- [ ] manual (required for feature branch merges and significant changes)

### Automation

- [ ] no changes are required
- [ ] existing tests have been updated
- [ ] new tests have been added
- [x] further changes are required by the automation team


[BIPS-32651]: https://beyondtrust.atlassian.net/browse/BIPS-32651?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ