### PR TITLE
Add context-aware HTTP API methods with backward-compatible wrappers

### DIFF
--- a/api/assets/assets.go
+++ b/api/assets/assets.go
@@ -4,6 +4,7 @@ package assets
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -33,7 +34,7 @@ func NewAssetObj(authentication authentication.AuthenticationObj, logger logging
 }
 
 // createAssetFlow is responsible for creating assets in Password Safe.
-func (assetObj *AssetObj) createAssetFlow(parameter string, assetDetails entities.AssetDetails) (entities.AssetResponse, error) {
+func (assetObj *AssetObj) createAssetFlow(ctx context.Context, parameter string, assetDetails entities.AssetDetails) (entities.AssetResponse, error) {
 
 	var assetResponse entities.AssetResponse
 
@@ -43,7 +44,7 @@ func (assetObj *AssetObj) createAssetFlow(parameter string, assetDetails entitie
 		return assetResponse, err
 	}
 
-	assetResponse, err = assetObj.createAsset(parameter, assetDetails)
+	assetResponse, err = assetObj.createAsset(ctx, parameter, assetDetails)
 
 	if err != nil {
 		return assetResponse, err
@@ -54,26 +55,36 @@ func (assetObj *AssetObj) createAssetFlow(parameter string, assetDetails entitie
 
 // CreateAssetByworkgroupIDFlow is responsible for creating assets using workgroup id in Password Safe.
 func (assetObj *AssetObj) CreateAssetByworkgroupIDFlow(workGroupId string, assetDetails entities.AssetDetails) (entities.AssetResponse, error) {
+	return assetObj.CreateAssetByworkgroupIDFlowWithContext(context.Background(), workGroupId, assetDetails)
+}
+
+// CreateAssetByworkgroupIDFlowWithContext is responsible for creating assets using workgroup id in Password Safe.
+func (assetObj *AssetObj) CreateAssetByworkgroupIDFlowWithContext(ctx context.Context, workGroupId string, assetDetails entities.AssetDetails) (entities.AssetResponse, error) {
 
 	if workGroupId == "" {
 		return entities.AssetResponse{}, errors.New("work groupId is empty, please send a valid workgroup id")
 	}
 
-	return assetObj.createAssetFlow(workGroupId, assetDetails)
+	return assetObj.createAssetFlow(ctx, workGroupId, assetDetails)
 }
 
 // CreateAssetByWorkGroupNameFlow is responsible for creating assets using workgroup name in Password Safe.
 func (assetObj *AssetObj) CreateAssetByWorkGroupNameFlow(workGroupName string, assetDetails entities.AssetDetails) (entities.AssetResponse, error) {
+	return assetObj.CreateAssetByWorkGroupNameFlowWithContext(context.Background(), workGroupName, assetDetails)
+}
+
+// CreateAssetByWorkGroupNameFlowWithContext is responsible for creating assets using workgroup name in Password Safe.
+func (assetObj *AssetObj) CreateAssetByWorkGroupNameFlowWithContext(ctx context.Context, workGroupName string, assetDetails entities.AssetDetails) (entities.AssetResponse, error) {
 
 	if workGroupName == "" {
 		return entities.AssetResponse{}, errors.New("workGroup name is empty, please send a valid workgroup name")
 	}
 
-	return assetObj.createAssetFlow(workGroupName, assetDetails)
+	return assetObj.createAssetFlow(ctx, workGroupName, assetDetails)
 }
 
 // createAsset calls Password Safe API enpoint to create assets.
-func (assetObj *AssetObj) createAsset(parameter string, assetDetails entities.AssetDetails) (entities.AssetResponse, error) {
+func (assetObj *AssetObj) createAsset(ctx context.Context, parameter string, assetDetails entities.AssetDetails) (entities.AssetResponse, error) {
 
 	path := fmt.Sprintf("workgroups/%s/assets", parameter)
 
@@ -98,6 +109,7 @@ func (assetObj *AssetObj) createAsset(parameter string, assetDetails entities.As
 	var businessError error
 
 	callSecretSafeAPIObj := &entities.CallSecretSafeAPIObj{
+		Ctx:         ctx,
 		Url:         createAssetUrl,
 		HttpMethod:  "POST",
 		Body:        *b,
@@ -109,7 +121,7 @@ func (assetObj *AssetObj) createAsset(parameter string, assetDetails entities.As
 	}
 
 	technicalError = backoff.Retry(func() error {
-		body, _, technicalError, businessError = assetObj.authenticationObj.HttpClient.CallSecretSafeAPI(*callSecretSafeAPIObj)
+		body, _, technicalError, businessError = assetObj.authenticationObj.HttpClient.CallSecretSafeAPIWithContext(ctx, *callSecretSafeAPIObj)
 		return technicalError
 	}, assetObj.authenticationObj.ExponentialBackOff)
 
@@ -142,19 +154,35 @@ func (assetObj *AssetObj) createAsset(parameter string, assetDetails entities.As
 
 // GetAssetsListByWorkgroupIdFlow get assets list by workgroup Id.
 func (platformObj *AssetObj) GetAssetsListByWorkgroupIdFlow(workgroupId string) ([]entities.AssetResponse, error) {
+	return platformObj.GetAssetsListByWorkgroupIdFlowWithContext(context.Background(), workgroupId)
+}
+
+// GetAssetsListByWorkgroupIdFlowWithContext get assets list by workgroup Id.
+func (platformObj *AssetObj) GetAssetsListByWorkgroupIdFlowWithContext(ctx context.Context, workgroupId string) ([]entities.AssetResponse, error) {
 	path := fmt.Sprintf("workgroups/%s/assets", workgroupId)
-	return platformObj.GetAssetsList(path, constants.GetAssetsListByWorkgroupId)
+	return platformObj.GetAssetsListWithContext(ctx, path, constants.GetAssetsListByWorkgroupId)
 }
 
 // GetAssetsListByWorkgroupNameFlow get assets list by workgroup name.
 func (platformObj *AssetObj) GetAssetsListByWorkgroupNameFlow(workgroupName string) ([]entities.AssetResponse, error) {
+	return platformObj.GetAssetsListByWorkgroupNameFlowWithContext(context.Background(), workgroupName)
+}
+
+// GetAssetsListByWorkgroupNameFlowWithContext get assets list by workgroup name.
+func (platformObj *AssetObj) GetAssetsListByWorkgroupNameFlowWithContext(ctx context.Context, workgroupName string) ([]entities.AssetResponse, error) {
 	path := fmt.Sprintf("workgroups/%s/assets", workgroupName)
-	return platformObj.GetAssetsList(path, constants.GetAssetsListByWorkgroupName)
+	return platformObj.GetAssetsListWithContext(ctx, path, constants.GetAssetsListByWorkgroupName)
 }
 
 // GetAssetsList call assets enpoint
 // and returns assets list
 func (platformObj *AssetObj) GetAssetsList(endpointPath string, method string) ([]entities.AssetResponse, error) {
+	return platformObj.GetAssetsListWithContext(context.Background(), endpointPath, method)
+}
+
+// GetAssetsListWithContext call assets enpoint
+// and returns assets list
+func (platformObj *AssetObj) GetAssetsListWithContext(ctx context.Context, endpointPath string, method string) ([]entities.AssetResponse, error) {
 	messageLog := fmt.Sprintf("%v %v", "GET", endpointPath)
 	platformObj.log.Debug(messageLog)
 
@@ -162,7 +190,7 @@ func (platformObj *AssetObj) GetAssetsList(endpointPath string, method string) (
 
 	var assetsList []entities.AssetResponse
 
-	response, err := platformObj.authenticationObj.HttpClient.GetGeneralList(url, platformObj.authenticationObj.ApiVersion, method, platformObj.authenticationObj.ExponentialBackOff)
+	response, err := platformObj.authenticationObj.HttpClient.GetGeneralListWithContext(ctx, url, platformObj.authenticationObj.ApiVersion, method, platformObj.authenticationObj.ExponentialBackOff)
 
 	if err != nil {
 		platformObj.log.Error(err.Error())
@@ -185,10 +213,16 @@ func (platformObj *AssetObj) GetAssetsList(endpointPath string, method string) (
 
 // DeleteAssetById deletes an asset by its ID.
 func (assetObj *AssetObj) DeleteAssetById(assetID int) error {
+	return assetObj.DeleteAssetByIdWithContext(context.Background(), assetID)
+}
+
+// DeleteAssetByIdWithContext deletes an asset by its ID.
+func (assetObj *AssetObj) DeleteAssetByIdWithContext(ctx context.Context, assetID int) error {
 	urlBuilder := func(id string) string {
 		return assetObj.authenticationObj.ApiUrl.JoinPath("Assets", id).String()
 	}
-	return utils.DeleteResourceByID(
+	return utils.DeleteResourceByIDWithContext(
+		ctx,
 		fmt.Sprintf("%d", assetID),
 		"asset",
 		constants.DeleteAsset,

--- a/api/authentication/authentication.go
+++ b/api/authentication/authentication.go
@@ -4,6 +4,7 @@ package authentication
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -90,17 +91,22 @@ func AuthenticateUsingApiKey(authenticationParametersObj AuthenticationParameter
 
 // GetPasswordSafeAuthentication is responsible for getting a token and signing in.
 func (authenticationObj *AuthenticationObj) GetPasswordSafeAuthentication() (entities.SignAppinResponse, error) {
+	return authenticationObj.GetPasswordSafeAuthenticationWithContext(context.Background())
+}
+
+// GetPasswordSafeAuthenticationWithContext is responsible for getting a token and signing in.
+func (authenticationObj *AuthenticationObj) GetPasswordSafeAuthenticationWithContext(ctx context.Context) (entities.SignAppinResponse, error) {
 	var accessToken string
 	var err error
 
 	if authenticationObj.clientId != "" && authenticationObj.clientSecret != "" {
-		accessToken, err = authenticationObj.GetToken(authenticationObj.ApiUrl.JoinPath("Auth/connect/token").String(), authenticationObj.clientId, authenticationObj.clientSecret)
+		accessToken, err = authenticationObj.GetTokenWithContext(ctx, authenticationObj.ApiUrl.JoinPath("Auth/connect/token").String(), authenticationObj.clientId, authenticationObj.clientSecret)
 		if err != nil {
 			return entities.SignAppinResponse{}, err
 		}
 	}
 
-	signApinResponse, err := authenticationObj.SignAppin(authenticationObj.ApiUrl.JoinPath("Auth/SignAppIn").String(), accessToken, authenticationObj.apiKey)
+	signApinResponse, err := authenticationObj.SignAppinWithContext(ctx, authenticationObj.ApiUrl.JoinPath("Auth/SignAppIn").String(), accessToken, authenticationObj.apiKey)
 	if err != nil {
 		return entities.SignAppinResponse{}, err
 	}
@@ -109,7 +115,12 @@ func (authenticationObj *AuthenticationObj) GetPasswordSafeAuthentication() (ent
 
 // GetToken is responsible for getting a token from the PS API.
 func (authenticationObj *AuthenticationObj) GetToken(endpointUrl string, clientId string, clientSecret string) (string, error) {
-	data, err := authenticationObj.GetTokenDetails(endpointUrl, clientId, clientSecret)
+	return authenticationObj.GetTokenWithContext(context.Background(), endpointUrl, clientId, clientSecret)
+}
+
+// GetTokenWithContext is responsible for getting a token from the PS API.
+func (authenticationObj *AuthenticationObj) GetTokenWithContext(ctx context.Context, endpointUrl string, clientId string, clientSecret string) (string, error) {
+	data, err := authenticationObj.GetTokenDetailsWithContext(ctx, endpointUrl, clientId, clientSecret)
 	if err != nil {
 		return "", err
 	}
@@ -122,6 +133,12 @@ func (authenticationObj *AuthenticationObj) GetToken(endpointUrl string, clientI
 // the complete entities.GetTokenResponse so callers can use expires_in to calculate
 // exact token expiry without relying on a hard-coded default lifetime.
 func (authenticationObj *AuthenticationObj) GetTokenDetails(endpointUrl string, clientId string, clientSecret string) (entities.GetTokenResponse, error) {
+	return authenticationObj.GetTokenDetailsWithContext(context.Background(), endpointUrl, clientId, clientSecret)
+}
+
+// GetTokenDetailsWithContext is responsible for getting a token from the PS API and returning
+// the full token response including expiry information.
+func (authenticationObj *AuthenticationObj) GetTokenDetailsWithContext(ctx context.Context, endpointUrl string, clientId string, clientSecret string) (entities.GetTokenResponse, error) {
 
 	params := url.Values{}
 	params.Add("client_id", clientId)
@@ -136,6 +153,7 @@ func (authenticationObj *AuthenticationObj) GetTokenDetails(endpointUrl string, 
 	buffer.WriteString(params.Encode())
 
 	callSecretSafeAPIObj := &entities.CallSecretSafeAPIObj{
+		Ctx:         ctx,
 		Url:         endpointUrl,
 		HttpMethod:  "POST",
 		Body:        buffer,
@@ -150,7 +168,7 @@ func (authenticationObj *AuthenticationObj) GetTokenDetails(endpointUrl string, 
 	authenticationObj.log.Debug(messageLog)
 
 	technicalError = backoff.Retry(func() error {
-		body, _, technicalError, businessError = authenticationObj.HttpClient.CallSecretSafeAPI(*callSecretSafeAPIObj)
+		body, _, technicalError, businessError = authenticationObj.HttpClient.CallSecretSafeAPIWithContext(ctx, *callSecretSafeAPIObj)
 		return technicalError
 	}, authenticationObj.ExponentialBackOff)
 
@@ -182,6 +200,11 @@ func (authenticationObj *AuthenticationObj) GetTokenDetails(endpointUrl string, 
 
 // SignAppin is responsible for creating a PS API session.
 func (authenticationObj *AuthenticationObj) SignAppin(endpointUrl string, accessToken string, apiKey string) (entities.SignAppinResponse, error) {
+	return authenticationObj.SignAppinWithContext(context.Background(), endpointUrl, accessToken, apiKey)
+}
+
+// SignAppinWithContext is responsible for creating a PS API session.
+func (authenticationObj *AuthenticationObj) SignAppinWithContext(ctx context.Context, endpointUrl string, accessToken string, apiKey string) (entities.SignAppinResponse, error) {
 
 	var userObject entities.SignAppinResponse
 	var body io.ReadCloser
@@ -190,6 +213,7 @@ func (authenticationObj *AuthenticationObj) SignAppin(endpointUrl string, access
 	var scode int
 
 	callSecretSafeAPIObj := &entities.CallSecretSafeAPIObj{
+		Ctx:         ctx,
 		Url:         endpointUrl,
 		HttpMethod:  "POST",
 		Body:        bytes.Buffer{},
@@ -204,7 +228,7 @@ func (authenticationObj *AuthenticationObj) SignAppin(endpointUrl string, access
 	authenticationObj.log.Debug(messageLog)
 
 	err := backoff.Retry(func() error {
-		body, scode, technicalError, businessError = authenticationObj.HttpClient.CallSecretSafeAPI(*callSecretSafeAPIObj)
+		body, scode, technicalError, businessError = authenticationObj.HttpClient.CallSecretSafeAPIWithContext(ctx, *callSecretSafeAPIObj)
 		if scode == 0 {
 			return nil
 		}
@@ -243,6 +267,13 @@ func (authenticationObj *AuthenticationObj) SignAppin(endpointUrl string, access
 // Warn: should only be called one time for all data sources. The session is closed server
 // side automatically after 20 minutes of uninterupted inactivity.
 func (authenticationObj *AuthenticationObj) SignOut() error {
+	return authenticationObj.SignOutWithContext(context.Background())
+}
+
+// SignOutWithContext is responsible for closing the PS API session and cleaning up idle connections.
+// Warn: should only be called one time for all data sources. The session is closed server
+// side automatically after 20 minutes of uninterupted inactivity.
+func (authenticationObj *AuthenticationObj) SignOutWithContext(ctx context.Context) error {
 
 	var technicalError error
 	var businessError error
@@ -251,6 +282,7 @@ func (authenticationObj *AuthenticationObj) SignOut() error {
 	signOutUrl := authenticationObj.ApiUrl.JoinPath("Auth/Signout").String()
 
 	callSecretSafeAPIObj := &entities.CallSecretSafeAPIObj{
+		Ctx:         ctx,
 		Url:         signOutUrl,
 		HttpMethod:  "POST",
 		Body:        bytes.Buffer{},
@@ -265,7 +297,7 @@ func (authenticationObj *AuthenticationObj) SignOut() error {
 	authenticationObj.log.Debug(messageLog)
 
 	technicalError = backoff.Retry(func() error {
-		body, _, technicalError, businessError = authenticationObj.HttpClient.CallSecretSafeAPI(*callSecretSafeAPIObj)
+		body, _, technicalError, businessError = authenticationObj.HttpClient.CallSecretSafeAPIWithContext(ctx, *callSecretSafeAPIObj)
 		return technicalError
 	}, authenticationObj.ExponentialBackOff)
 

--- a/api/databases/databases.go
+++ b/api/databases/databases.go
@@ -4,6 +4,7 @@ package databases
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -36,6 +37,11 @@ func NewDatabaseObj(authentication authentication.AuthenticationObj, logger logg
 
 // CreateDatabaseFlow is responsible for creating databases in Password Safe.
 func (databaseObj *DatabaseObj) CreateDatabaseFlow(assetId string, databaseDetails entities.DatabaseDetails) (entities.DatabaseResponse, error) {
+	return databaseObj.CreateDatabaseFlowWithContext(context.Background(), assetId, databaseDetails)
+}
+
+// CreateDatabaseFlowWithContext is responsible for creating databases in Password Safe.
+func (databaseObj *DatabaseObj) CreateDatabaseFlowWithContext(ctx context.Context, assetId string, databaseDetails entities.DatabaseDetails) (entities.DatabaseResponse, error) {
 
 	var databaseResponse entities.DatabaseResponse
 
@@ -49,7 +55,7 @@ func (databaseObj *DatabaseObj) CreateDatabaseFlow(assetId string, databaseDetai
 		return databaseResponse, err
 	}
 
-	databaseResponse, err = databaseObj.createDatabase(assetId, databaseDetails)
+	databaseResponse, err = databaseObj.createDatabase(ctx, assetId, databaseDetails)
 
 	if err != nil {
 		return databaseResponse, err
@@ -59,7 +65,7 @@ func (databaseObj *DatabaseObj) CreateDatabaseFlow(assetId string, databaseDetai
 }
 
 // createDatabase calls Password Safe API enpoint to create databases.
-func (databaseObj *DatabaseObj) createDatabase(assetId string, database entities.DatabaseDetails) (entities.DatabaseResponse, error) {
+func (databaseObj *DatabaseObj) createDatabase(ctx context.Context, assetId string, database entities.DatabaseDetails) (entities.DatabaseResponse, error) {
 
 	path := "Assets/{id}/Databases"
 	path = strings.Replace(path, "{id}", assetId, 1)
@@ -87,6 +93,7 @@ func (databaseObj *DatabaseObj) createDatabase(assetId string, database entities
 	var businessError error
 
 	callSecretSafeAPIObj := &entities.CallSecretSafeAPIObj{
+		Ctx:         ctx,
 		Url:         createDatabaseUrl,
 		HttpMethod:  "POST",
 		Body:        *b,
@@ -98,7 +105,7 @@ func (databaseObj *DatabaseObj) createDatabase(assetId string, database entities
 	}
 
 	technicalError = backoff.Retry(func() error {
-		body, _, technicalError, businessError = databaseObj.authenticationObj.HttpClient.CallSecretSafeAPI(*callSecretSafeAPIObj)
+		body, _, technicalError, businessError = databaseObj.authenticationObj.HttpClient.CallSecretSafeAPIWithContext(ctx, *callSecretSafeAPIObj)
 		return technicalError
 	}, databaseObj.authenticationObj.ExponentialBackOff)
 
@@ -130,12 +137,23 @@ func (databaseObj *DatabaseObj) createDatabase(assetId string, database entities
 
 // GetDatabasesListFlow get databases list.
 func (databaseObj *DatabaseObj) GetDatabasesListFlow() ([]entities.DatabaseResponse, error) {
-	return databaseObj.GetDatabasesList("Databases", constants.GetDataBasesList)
+	return databaseObj.GetDatabasesListFlowWithContext(context.Background())
+}
+
+// GetDatabasesListFlowWithContext gets databases list.
+func (databaseObj *DatabaseObj) GetDatabasesListFlowWithContext(ctx context.Context) ([]entities.DatabaseResponse, error) {
+	return databaseObj.GetDatabasesListWithContext(ctx, "Databases", constants.GetDataBasesList)
 }
 
 // GetDatabasesList call Databases enpoint
 // and returns databases list
 func (databaseObj *DatabaseObj) GetDatabasesList(endpointPath string, method string) ([]entities.DatabaseResponse, error) {
+	return databaseObj.GetDatabasesListWithContext(context.Background(), endpointPath, method)
+}
+
+// GetDatabasesListWithContext calls Databases endpoint
+// and returns databases list
+func (databaseObj *DatabaseObj) GetDatabasesListWithContext(ctx context.Context, endpointPath string, method string) ([]entities.DatabaseResponse, error) {
 	messageLog := fmt.Sprintf("%v %v", "GET", endpointPath)
 	databaseObj.log.Debug(messageLog)
 
@@ -143,7 +161,7 @@ func (databaseObj *DatabaseObj) GetDatabasesList(endpointPath string, method str
 
 	var databasesList []entities.DatabaseResponse
 
-	response, err := databaseObj.authenticationObj.HttpClient.GetGeneralList(url, databaseObj.authenticationObj.ApiVersion, method, databaseObj.authenticationObj.ExponentialBackOff)
+	response, err := databaseObj.authenticationObj.HttpClient.GetGeneralListWithContext(ctx, url, databaseObj.authenticationObj.ApiVersion, method, databaseObj.authenticationObj.ExponentialBackOff)
 
 	if err != nil {
 		return databasesList, err
@@ -165,10 +183,16 @@ func (databaseObj *DatabaseObj) GetDatabasesList(endpointPath string, method str
 
 // DeleteDatabaseById deletes a database by its ID.
 func (databaseObj *DatabaseObj) DeleteDatabaseById(databaseID int) error {
+	return databaseObj.DeleteDatabaseByIdWithContext(context.Background(), databaseID)
+}
+
+// DeleteDatabaseByIdWithContext deletes a database by its ID.
+func (databaseObj *DatabaseObj) DeleteDatabaseByIdWithContext(ctx context.Context, databaseID int) error {
 	urlBuilder := func(id string) string {
 		return databaseObj.authenticationObj.ApiUrl.JoinPath("Databases", id).String()
 	}
-	return utils.DeleteResourceByID(
+	return utils.DeleteResourceByIDWithContext(
+		ctx,
 		fmt.Sprintf("%d", databaseID),
 		"database",
 		constants.DeleteDatabase,

--- a/api/entities/entities.go
+++ b/api/entities/entities.go
@@ -4,6 +4,7 @@ package entities
 
 import (
 	"bytes"
+	"context"
 
 	"github.com/google/uuid"
 )
@@ -285,6 +286,7 @@ type FolderDetails struct {
 }
 
 type CallSecretSafeAPIObj struct {
+	Ctx         context.Context
 	Url         string
 	HttpMethod  string
 	Body        bytes.Buffer

--- a/api/functional_accounts/functional_accounts.go
+++ b/api/functional_accounts/functional_accounts.go
@@ -4,6 +4,7 @@ package functional_accounts
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 
@@ -32,6 +33,11 @@ func NewFuncionalAccount(authentication authentication.AuthenticationObj, logger
 
 // CreateFunctionalAccountFlow is responsible for creating functional accounts in Password Safe.
 func (functionalAccount *FunctionalAccount) CreateFunctionalAccountFlow(functionalAccountDetails entities.FunctionalAccountDetails) (entities.FunctionalAccountResponse, error) {
+	return functionalAccount.CreateFunctionalAccountFlowWithContext(context.Background(), functionalAccountDetails)
+}
+
+// CreateFunctionalAccountFlowWithContext is responsible for creating functional accounts in Password Safe.
+func (functionalAccount *FunctionalAccount) CreateFunctionalAccountFlowWithContext(ctx context.Context, functionalAccountDetails entities.FunctionalAccountDetails) (entities.FunctionalAccountResponse, error) {
 
 	var functionalAccountResponse entities.FunctionalAccountResponse
 	var err error
@@ -41,7 +47,7 @@ func (functionalAccount *FunctionalAccount) CreateFunctionalAccountFlow(function
 		return functionalAccountResponse, err
 	}
 
-	functionalAccountResponse, err = functionalAccount.createFunctionalAccount(constants.CreateFunctionalAccount, "POST", endpointPath, functionalAccountDetails)
+	functionalAccountResponse, err = functionalAccount.createFunctionalAccount(ctx, constants.CreateFunctionalAccount, "POST", endpointPath, functionalAccountDetails)
 
 	if err != nil {
 		return functionalAccountResponse, err
@@ -53,11 +59,16 @@ func (functionalAccount *FunctionalAccount) CreateFunctionalAccountFlow(function
 
 // GetFunctionalAccountsFlow is responsible for getting functional accounts list from Password Safe.
 func (functionalAccount *FunctionalAccount) GetFunctionalAccountsFlow() ([]entities.FunctionalAccountResponse, error) {
+	return functionalAccount.GetFunctionalAccountsFlowWithContext(context.Background())
+}
+
+// GetFunctionalAccountsFlowWithContext is responsible for getting functional accounts list from Password Safe.
+func (functionalAccount *FunctionalAccount) GetFunctionalAccountsFlowWithContext(ctx context.Context) ([]entities.FunctionalAccountResponse, error) {
 
 	var functionalAccountResponse []entities.FunctionalAccountResponse
 	var err error
 
-	functionalAccountResponse, err = functionalAccount.GetFunctionalAccountsListFlow(constants.GetFunctionalAccount, "GET", endpointPath)
+	functionalAccountResponse, err = functionalAccount.GetFunctionalAccountsListFlowWithContext(ctx, constants.GetFunctionalAccount, "GET", endpointPath)
 
 	if err != nil {
 		return functionalAccountResponse, err
@@ -68,7 +79,7 @@ func (functionalAccount *FunctionalAccount) GetFunctionalAccountsFlow() ([]entit
 }
 
 // createFunctionalAccount calls Password Safe API enpoint to create functional account.
-func (functionalAccount *FunctionalAccount) createFunctionalAccount(method string, httpMethod string, path string, functionalAccountDetails entities.FunctionalAccountDetails) (entities.FunctionalAccountResponse, error) {
+func (functionalAccount *FunctionalAccount) createFunctionalAccount(ctx context.Context, method string, httpMethod string, path string, functionalAccountDetails entities.FunctionalAccountDetails) (entities.FunctionalAccountResponse, error) {
 
 	var err error
 	var functionalAccountResponse entities.FunctionalAccountResponse
@@ -87,6 +98,7 @@ func (functionalAccount *FunctionalAccount) createFunctionalAccount(method strin
 	functionalAccount.log.Debug(messageLog)
 
 	callSecretSafeAPIObj := &entities.CallSecretSafeAPIObj{
+		Ctx:         ctx,
 		Url:         createManagedSystemUrl,
 		HttpMethod:  httpMethod,
 		Body:        *b,
@@ -97,7 +109,7 @@ func (functionalAccount *FunctionalAccount) createFunctionalAccount(method strin
 		ApiVersion:  functionalAccount.authenticationObj.ApiVersion,
 	}
 
-	response, err := functionalAccount.authenticationObj.HttpClient.MakeRequest(callSecretSafeAPIObj, functionalAccount.authenticationObj.ExponentialBackOff)
+	response, err := functionalAccount.authenticationObj.HttpClient.MakeRequestWithContext(ctx, callSecretSafeAPIObj, functionalAccount.authenticationObj.ExponentialBackOff)
 
 	if err != nil {
 		return functionalAccountResponse, err
@@ -114,6 +126,11 @@ func (functionalAccount *FunctionalAccount) createFunctionalAccount(method strin
 
 // GetFunctionalAccountsListFlow calls Password Safe API enpoint to get functional accounts list.
 func (functionalAccount *FunctionalAccount) GetFunctionalAccountsListFlow(method string, httpMethod string, path string) ([]entities.FunctionalAccountResponse, error) {
+	return functionalAccount.GetFunctionalAccountsListFlowWithContext(context.Background(), method, httpMethod, path)
+}
+
+// GetFunctionalAccountsListFlowWithContext calls Password Safe API endpoint to get functional accounts list.
+func (functionalAccount *FunctionalAccount) GetFunctionalAccountsListFlowWithContext(ctx context.Context, method string, httpMethod string, path string) ([]entities.FunctionalAccountResponse, error) {
 	messageLog := fmt.Sprintf("%v %v", "GET", path)
 	functionalAccount.log.Debug(messageLog)
 
@@ -122,7 +139,7 @@ func (functionalAccount *FunctionalAccount) GetFunctionalAccountsListFlow(method
 
 	createManagedSystemUrl := functionalAccount.authenticationObj.ApiUrl.JoinPath(path).String()
 
-	response, err := functionalAccount.authenticationObj.HttpClient.GetGeneralList(createManagedSystemUrl, functionalAccount.authenticationObj.ApiVersion, method, functionalAccount.authenticationObj.ExponentialBackOff)
+	response, err := functionalAccount.authenticationObj.HttpClient.GetGeneralListWithContext(ctx, createManagedSystemUrl, functionalAccount.authenticationObj.ApiVersion, method, functionalAccount.authenticationObj.ExponentialBackOff)
 
 	if err != nil {
 		return functionalAccountResponse, err
@@ -144,10 +161,16 @@ func (functionalAccount *FunctionalAccount) GetFunctionalAccountsListFlow(method
 
 // DeleteFunctionalAccountById deletes a functional account by its ID.
 func (functionalAccount *FunctionalAccount) DeleteFunctionalAccountById(functionalAccountID int) error {
+	return functionalAccount.DeleteFunctionalAccountByIdWithContext(context.Background(), functionalAccountID)
+}
+
+// DeleteFunctionalAccountByIdWithContext deletes a functional account by its ID.
+func (functionalAccount *FunctionalAccount) DeleteFunctionalAccountByIdWithContext(ctx context.Context, functionalAccountID int) error {
 	urlBuilder := func(id string) string {
 		return functionalAccount.authenticationObj.ApiUrl.JoinPath("FunctionalAccounts", id).String()
 	}
-	return utils.DeleteResourceByID(
+	return utils.DeleteResourceByIDWithContext(
+		ctx,
 		fmt.Sprintf("%d", functionalAccountID),
 		"functional account",
 		constants.DeleteFunctionalAccount,

--- a/api/managed_account/managed_account.go
+++ b/api/managed_account/managed_account.go
@@ -4,6 +4,7 @@ package managed_accounts
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -37,19 +38,34 @@ func NewManagedAccountObj(authentication authentication.AuthenticationObj, logge
 
 // GetSecrets is responsible for getting a list of managed account secret values based on the list of systems and account names.
 func (managedAccountObj *ManagedAccountstObj) GetSecrets(secretPaths []string, separator string) (map[string]string, error) {
-	return managedAccountObj.ManageAccountFlow(secretPaths, separator)
+	return managedAccountObj.GetSecretsWithContext(context.Background(), secretPaths, separator)
+}
+
+// GetSecretsWithContext is responsible for getting a list of managed account secret values based on the list of systems and account names.
+func (managedAccountObj *ManagedAccountstObj) GetSecretsWithContext(ctx context.Context, secretPaths []string, separator string) (map[string]string, error) {
+	return managedAccountObj.ManageAccountFlowWithContext(ctx, secretPaths, separator)
 }
 
 // GetSecret returns secret value for a specific System Name and Account Name.
 func (managedAccountObj *ManagedAccountstObj) GetSecret(secretPath string, separator string) (string, error) {
+	return managedAccountObj.GetSecretWithContext(context.Background(), secretPath, separator)
+}
+
+// GetSecretWithContext returns secret value for a specific System Name and Account Name.
+func (managedAccountObj *ManagedAccountstObj) GetSecretWithContext(ctx context.Context, secretPath string, separator string) (string, error) {
 	managedAccountList := []string{}
-	secrets, err := managedAccountObj.ManageAccountFlow(append(managedAccountList, secretPath), separator)
+	secrets, err := managedAccountObj.ManageAccountFlowWithContext(ctx, append(managedAccountList, secretPath), separator)
 	secretValue := secrets[secretPath]
 	return secretValue, err
 }
 
 // ManageAccountFlow is responsible for creating a dictionary of managed account system/name and secret key-value pairs.
 func (managedAccountObj *ManagedAccountstObj) ManageAccountFlow(secretsToRetrieve []string, separator string) (map[string]string, error) {
+	return managedAccountObj.ManageAccountFlowWithContext(context.Background(), secretsToRetrieve, separator)
+}
+
+// ManageAccountFlowWithContext is responsible for creating a dictionary of managed account system/name and secret key-value pairs.
+func (managedAccountObj *ManagedAccountstObj) ManageAccountFlowWithContext(ctx context.Context, secretsToRetrieve []string, separator string) (map[string]string, error) {
 
 	secretsToRetrieve = utils.ValidatePaths(secretsToRetrieve, true, separator, managedAccountObj.log)
 	managedAccountObj.log.Info(fmt.Sprintf("Retrieving %v Secrets", len(secretsToRetrieve)))
@@ -72,7 +88,7 @@ func (managedAccountObj *ManagedAccountstObj) ManageAccountFlow(secretsToRetriev
 		var err error
 
 		ManagedAccountGetUrl := managedAccountObj.authenticationObj.ApiUrl.JoinPath("ManagedAccounts").String() + "?" + v.Encode()
-		managedAccount, err := managedAccountObj.ManagedAccountGet(systemName, accountName, ManagedAccountGetUrl)
+		managedAccount, err := managedAccountObj.ManagedAccountGetWithContext(ctx, systemName, accountName, ManagedAccountGetUrl)
 		if err != nil {
 			saveLastErr = err
 			managedAccountObj.log.Error(fmt.Sprintf("%v secretsPath: %v %v %v", err.Error(), systemName, separator, accountName))
@@ -80,7 +96,7 @@ func (managedAccountObj *ManagedAccountstObj) ManageAccountFlow(secretsToRetriev
 		}
 
 		ManagedAccountCreateRequestUrl := managedAccountObj.authenticationObj.ApiUrl.JoinPath("Requests").String()
-		requestId, err := managedAccountObj.ManagedAccountCreateRequest(managedAccount.SystemId, managedAccount.AccountId, ManagedAccountCreateRequestUrl)
+		requestId, err := managedAccountObj.ManagedAccountCreateRequestWithContext(ctx, managedAccount.SystemId, managedAccount.AccountId, ManagedAccountCreateRequestUrl)
 		if err != nil {
 			saveLastErr = err
 			managedAccountObj.log.Error(fmt.Sprintf("%v secretsPath: %v %v %v", err.Error(), systemName, separator, accountName))
@@ -88,7 +104,7 @@ func (managedAccountObj *ManagedAccountstObj) ManageAccountFlow(secretsToRetriev
 		}
 
 		CredentialByRequestIdUrl := managedAccountObj.authenticationObj.ApiUrl.JoinPath("Credentials", requestId).String()
-		secret, err := managedAccountObj.CredentialByRequestId(requestId, CredentialByRequestIdUrl)
+		secret, err := managedAccountObj.CredentialByRequestIdWithContext(ctx, requestId, CredentialByRequestIdUrl)
 		if err != nil {
 			saveLastErr = err
 			managedAccountObj.log.Error(fmt.Sprintf("%v secretsPath: %v %v %v", err.Error(), systemName, separator, accountName))
@@ -96,7 +112,7 @@ func (managedAccountObj *ManagedAccountstObj) ManageAccountFlow(secretsToRetriev
 		}
 
 		ManagedAccountRequestCheckInUrl := managedAccountObj.authenticationObj.ApiUrl.JoinPath("Requests", requestId, "checkin").String()
-		_, err = managedAccountObj.ManagedAccountRequestCheckIn(requestId, ManagedAccountRequestCheckInUrl)
+		_, err = managedAccountObj.ManagedAccountRequestCheckInWithContext(ctx, requestId, ManagedAccountRequestCheckInUrl)
 
 		if err != nil {
 			saveLastErr = err
@@ -114,6 +130,11 @@ func (managedAccountObj *ManagedAccountstObj) ManageAccountFlow(secretsToRetriev
 
 // ManagedAccountGet is responsible for retrieving a managed account secret based on the system and name.
 func (managedAccountObj *ManagedAccountstObj) ManagedAccountGet(systemName string, accountName string, url string) (entities.ManagedAccount, error) {
+	return managedAccountObj.ManagedAccountGetWithContext(context.Background(), systemName, accountName, url)
+}
+
+// ManagedAccountGetWithContext is responsible for retrieving a managed account secret based on the system and name.
+func (managedAccountObj *ManagedAccountstObj) ManagedAccountGetWithContext(ctx context.Context, systemName string, accountName string, url string) (entities.ManagedAccount, error) {
 	messageLog := fmt.Sprintf("%v %v", "GET", url)
 	managedAccountObj.log.Debug(messageLog)
 
@@ -122,6 +143,7 @@ func (managedAccountObj *ManagedAccountstObj) ManagedAccountGet(systemName strin
 	var businessError error
 
 	callSecretSafeAPIObj := &entities.CallSecretSafeAPIObj{
+		Ctx:         ctx,
 		Url:         url,
 		HttpMethod:  "GET",
 		Body:        bytes.Buffer{},
@@ -133,7 +155,7 @@ func (managedAccountObj *ManagedAccountstObj) ManagedAccountGet(systemName strin
 	}
 
 	technicalError = backoff.Retry(func() error {
-		body, _, technicalError, businessError = managedAccountObj.authenticationObj.HttpClient.CallSecretSafeAPI(*callSecretSafeAPIObj)
+		body, _, technicalError, businessError = managedAccountObj.authenticationObj.HttpClient.CallSecretSafeAPIWithContext(ctx, *callSecretSafeAPIObj)
 		if technicalError != nil {
 			return technicalError
 		}
@@ -169,27 +191,43 @@ func (managedAccountObj *ManagedAccountstObj) ManagedAccountGet(systemName strin
 
 // ManagedAccountCreateRequest calls Secret Safe API Requests enpoint and returns a request Id as string.
 func (managedAccountObj *ManagedAccountstObj) ManagedAccountCreateRequest(systemName int, accountName int, url string) (string, error) {
+	return managedAccountObj.ManagedAccountCreateRequestWithContext(context.Background(), systemName, accountName, url)
+}
+
+// ManagedAccountCreateRequestWithContext calls Secret Safe API Requests endpoint and returns a request Id as string.
+func (managedAccountObj *ManagedAccountstObj) ManagedAccountCreateRequestWithContext(ctx context.Context, systemName int, accountName int, url string) (string, error) {
 	messageLog := fmt.Sprintf("%v %v", "POST", url)
 	managedAccountObj.log.Debug(messageLog)
 
 	data := fmt.Sprintf(`{"SystemID":%v, "AccountID":%v, "DurationMinutes":5, "Reason":"Tesr", "ConflictOption": "reuse"}`, systemName, accountName)
 	b := bytes.NewBufferString(data)
 
-	return managedAccountObj.sendRequestAndGetSingleString("POST", url, constants.ManagedAccountCreateRequest, *b)
+	return managedAccountObj.sendRequestAndGetSingleString(ctx, "POST", url, constants.ManagedAccountCreateRequest, *b)
 
 }
 
 // CredentialByRequestId calls Secret Safe API Credentials/<request_id>
 // enpoint and returns secret value by request Id.
 func (managedAccountObj *ManagedAccountstObj) CredentialByRequestId(requestId string, url string) (string, error) {
+	return managedAccountObj.CredentialByRequestIdWithContext(context.Background(), requestId, url)
+}
+
+// CredentialByRequestIdWithContext calls Secret Safe API Credentials/<request_id>
+// endpoint and returns secret value by request Id.
+func (managedAccountObj *ManagedAccountstObj) CredentialByRequestIdWithContext(ctx context.Context, requestId string, url string) (string, error) {
 	messageLog := fmt.Sprintf("%v %v", "GET", url)
 	managedAccountObj.log.Debug(strings.ReplaceAll(messageLog, requestId, "****"))
-	return managedAccountObj.sendRequestAndGetSingleString("GET", url, constants.CredentialByRequestId, bytes.Buffer{})
+	return managedAccountObj.sendRequestAndGetSingleString(ctx, "GET", url, constants.CredentialByRequestId, bytes.Buffer{})
 
 }
 
 // ManagedAccountRequestCheckIn calls Secret Safe API "Requests/<request_id>/checkin enpoint.
 func (managedAccountObj *ManagedAccountstObj) ManagedAccountRequestCheckIn(requestId string, url string) (string, error) {
+	return managedAccountObj.ManagedAccountRequestCheckInWithContext(context.Background(), requestId, url)
+}
+
+// ManagedAccountRequestCheckInWithContext calls Secret Safe API "Requests/<request_id>/checkin endpoint.
+func (managedAccountObj *ManagedAccountstObj) ManagedAccountRequestCheckInWithContext(ctx context.Context, requestId string, url string) (string, error) {
 	messageLog := fmt.Sprintf("%v %v", "PUT", url)
 	managedAccountObj.log.Debug(strings.ReplaceAll(messageLog, requestId, "****"))
 
@@ -200,6 +238,7 @@ func (managedAccountObj *ManagedAccountstObj) ManagedAccountRequestCheckIn(reque
 	var businessError error
 
 	callSecretSafeAPIObj := &entities.CallSecretSafeAPIObj{
+		Ctx:         ctx,
 		Url:         url,
 		HttpMethod:  "PUT",
 		Body:        *b,
@@ -211,7 +250,7 @@ func (managedAccountObj *ManagedAccountstObj) ManagedAccountRequestCheckIn(reque
 	}
 
 	technicalError = backoff.Retry(func() error {
-		_, _, technicalError, businessError = managedAccountObj.authenticationObj.HttpClient.CallSecretSafeAPI(*callSecretSafeAPIObj)
+		_, _, technicalError, businessError = managedAccountObj.authenticationObj.HttpClient.CallSecretSafeAPIWithContext(ctx, *callSecretSafeAPIObj)
 		return technicalError
 	}, managedAccountObj.authenticationObj.ExponentialBackOff)
 
@@ -228,6 +267,11 @@ func (managedAccountObj *ManagedAccountstObj) ManagedAccountRequestCheckIn(reque
 
 // ManageAccountCreateFlow is responsible for creating a managed accounts in Password Safe.
 func (managedAccountObj *ManagedAccountstObj) ManageAccountCreateFlow(systemNameTarget string, accountDetails entities.AccountDetails) (entities.CreateManagedAccountsResponse, error) {
+	return managedAccountObj.ManageAccountCreateFlowWithContext(context.Background(), systemNameTarget, accountDetails)
+}
+
+// ManageAccountCreateFlowWithContext is responsible for creating a managed accounts in Password Safe.
+func (managedAccountObj *ManagedAccountstObj) ManageAccountCreateFlowWithContext(ctx context.Context, systemNameTarget string, accountDetails entities.AccountDetails) (entities.CreateManagedAccountsResponse, error) {
 
 	var managedSystem *entities.ManagedSystemResponse
 	var createResponse entities.CreateManagedAccountsResponse
@@ -239,7 +283,7 @@ func (managedAccountObj *ManagedAccountstObj) ManageAccountCreateFlow(systemName
 	}
 
 	ManagedAccountSystemUrl := managedAccountObj.authenticationObj.ApiUrl.JoinPath("ManagedSystems").String()
-	managedSystemGetSystemsResponse, err := managedAccountObj.ManagedSystemGetSystems(ManagedAccountSystemUrl)
+	managedSystemGetSystemsResponse, err := managedAccountObj.ManagedSystemGetSystemsWithContext(ctx, ManagedAccountSystemUrl)
 
 	if err != nil {
 		return createResponse, err
@@ -257,7 +301,7 @@ func (managedAccountObj *ManagedAccountstObj) ManageAccountCreateFlow(systemName
 	}
 
 	ManagedAccountCreateManagedAccountUrl := managedAccountObj.authenticationObj.ApiUrl.JoinPath("ManagedSystems", fmt.Sprintf("%d", managedSystem.ManagedSystemID), "ManagedAccounts").String()
-	createResponse, err = managedAccountObj.ManagedAccountCreateManagedAccount(accountDetails, ManagedAccountCreateManagedAccountUrl)
+	createResponse, err = managedAccountObj.ManagedAccountCreateManagedAccountWithContext(ctx, accountDetails, ManagedAccountCreateManagedAccountUrl)
 
 	if err != nil {
 		return createResponse, err
@@ -269,6 +313,11 @@ func (managedAccountObj *ManagedAccountstObj) ManageAccountCreateFlow(systemName
 
 // ManagedAccountCreateManagedAccount calls Secret Safe API Requests enpoint to create managed accounts.
 func (managedAccountObj *ManagedAccountstObj) ManagedAccountCreateManagedAccount(accountDetails entities.AccountDetails, url string) (entities.CreateManagedAccountsResponse, error) {
+	return managedAccountObj.ManagedAccountCreateManagedAccountWithContext(context.Background(), accountDetails, url)
+}
+
+// ManagedAccountCreateManagedAccountWithContext calls Secret Safe API Requests endpoint to create managed accounts.
+func (managedAccountObj *ManagedAccountstObj) ManagedAccountCreateManagedAccountWithContext(ctx context.Context, accountDetails entities.AccountDetails, url string) (entities.CreateManagedAccountsResponse, error) {
 	messageLog := fmt.Sprintf("%v %v", "POST", url)
 	managedAccountObj.log.Debug(messageLog)
 
@@ -286,6 +335,7 @@ func (managedAccountObj *ManagedAccountstObj) ManagedAccountCreateManagedAccount
 	var businessError error
 
 	callSecretSafeAPIObj := &entities.CallSecretSafeAPIObj{
+		Ctx:         ctx,
 		Url:         url,
 		HttpMethod:  "POST",
 		Body:        *b,
@@ -297,7 +347,7 @@ func (managedAccountObj *ManagedAccountstObj) ManagedAccountCreateManagedAccount
 	}
 
 	technicalError = backoff.Retry(func() error {
-		body, _, technicalError, businessError = managedAccountObj.authenticationObj.HttpClient.CallSecretSafeAPI(*callSecretSafeAPIObj)
+		body, _, technicalError, businessError = managedAccountObj.authenticationObj.HttpClient.CallSecretSafeAPIWithContext(ctx, *callSecretSafeAPIObj)
 		return technicalError
 	}, managedAccountObj.authenticationObj.ExponentialBackOff)
 
@@ -331,6 +381,11 @@ func (managedAccountObj *ManagedAccountstObj) ManagedAccountCreateManagedAccount
 
 // ManagedAccountGetSystem is responsible for retrieving managed systems list
 func (managedAccountObj *ManagedAccountstObj) ManagedSystemGetSystems(url string) ([]entities.ManagedSystemResponse, error) {
+	return managedAccountObj.ManagedSystemGetSystemsWithContext(context.Background(), url)
+}
+
+// ManagedSystemGetSystemsWithContext is responsible for retrieving managed systems list.
+func (managedAccountObj *ManagedAccountstObj) ManagedSystemGetSystemsWithContext(ctx context.Context, url string) ([]entities.ManagedSystemResponse, error) {
 	messageLog := fmt.Sprintf("%v %v", "GET", url)
 	managedAccountObj.log.Debug(messageLog)
 
@@ -339,6 +394,7 @@ func (managedAccountObj *ManagedAccountstObj) ManagedSystemGetSystems(url string
 	var businessError error
 
 	callSecretSafeAPIObj := &entities.CallSecretSafeAPIObj{
+		Ctx:         ctx,
 		Url:         url,
 		HttpMethod:  "GET",
 		Body:        bytes.Buffer{},
@@ -350,7 +406,7 @@ func (managedAccountObj *ManagedAccountstObj) ManagedSystemGetSystems(url string
 	}
 
 	technicalError = backoff.Retry(func() error {
-		body, _, technicalError, businessError = managedAccountObj.authenticationObj.HttpClient.CallSecretSafeAPI(*callSecretSafeAPIObj)
+		body, _, technicalError, businessError = managedAccountObj.authenticationObj.HttpClient.CallSecretSafeAPIWithContext(ctx, *callSecretSafeAPIObj)
 		if technicalError != nil {
 			return technicalError
 		}
@@ -391,12 +447,23 @@ func (managedAccountObj *ManagedAccountstObj) ManagedSystemGetSystems(url string
 
 // GetManagedAccountsListFlow get managed accounts list.
 func (managedAccountObj *ManagedAccountstObj) GetManagedAccountsListFlow() ([]entities.ManagedAccount, error) {
-	return managedAccountObj.GetManagedAccountsList("ManagedAccounts", constants.ManagedAccountCreate)
+	return managedAccountObj.GetManagedAccountsListFlowWithContext(context.Background())
+}
+
+// GetManagedAccountsListFlowWithContext gets managed accounts list.
+func (managedAccountObj *ManagedAccountstObj) GetManagedAccountsListFlowWithContext(ctx context.Context) ([]entities.ManagedAccount, error) {
+	return managedAccountObj.GetManagedAccountsListWithContext(ctx, "ManagedAccounts", constants.ManagedAccountCreate)
 }
 
 // GetManagedAccountsList call ManagedAccounts enpoint
 // and returns managed accounts list
 func (managedAccountObj *ManagedAccountstObj) GetManagedAccountsList(endpointPath string, method string) ([]entities.ManagedAccount, error) {
+	return managedAccountObj.GetManagedAccountsListWithContext(context.Background(), endpointPath, method)
+}
+
+// GetManagedAccountsListWithContext calls ManagedAccounts endpoint
+// and returns managed accounts list
+func (managedAccountObj *ManagedAccountstObj) GetManagedAccountsListWithContext(ctx context.Context, endpointPath string, method string) ([]entities.ManagedAccount, error) {
 
 	messageLog := fmt.Sprintf("%v %v", "GET", endpointPath)
 	managedAccountObj.log.Debug(messageLog)
@@ -405,7 +472,7 @@ func (managedAccountObj *ManagedAccountstObj) GetManagedAccountsList(endpointPat
 
 	var managedAccountList []entities.ManagedAccount
 
-	response, err := managedAccountObj.authenticationObj.HttpClient.GetGeneralList(url, managedAccountObj.authenticationObj.ApiVersion, method, managedAccountObj.authenticationObj.ExponentialBackOff)
+	response, err := managedAccountObj.authenticationObj.HttpClient.GetGeneralListWithContext(ctx, url, managedAccountObj.authenticationObj.ApiVersion, method, managedAccountObj.authenticationObj.ExponentialBackOff)
 
 	if err != nil {
 		return managedAccountList, err
@@ -426,13 +493,14 @@ func (managedAccountObj *ManagedAccountstObj) GetManagedAccountsList(endpointPat
 }
 
 // sendRequestAndGetSingleString send a request and get the response as string.
-func (managedAccountObj *ManagedAccountstObj) sendRequestAndGetSingleString(httpMethod string, url string, method string, b bytes.Buffer) (string, error) {
+func (managedAccountObj *ManagedAccountstObj) sendRequestAndGetSingleString(ctx context.Context, httpMethod string, url string, method string, b bytes.Buffer) (string, error) {
 
 	var body io.ReadCloser
 	var technicalError error
 	var businessError error
 
 	callSecretSafeAPIObj := &entities.CallSecretSafeAPIObj{
+		Ctx:         ctx,
 		Url:         url,
 		HttpMethod:  httpMethod,
 		Body:        b,
@@ -443,7 +511,7 @@ func (managedAccountObj *ManagedAccountstObj) sendRequestAndGetSingleString(http
 		ApiVersion:  "",
 	}
 	technicalError = backoff.Retry(func() error {
-		body, _, technicalError, businessError = managedAccountObj.authenticationObj.HttpClient.CallSecretSafeAPI(*callSecretSafeAPIObj)
+		body, _, technicalError, businessError = managedAccountObj.authenticationObj.HttpClient.CallSecretSafeAPIWithContext(ctx, *callSecretSafeAPIObj)
 		return technicalError
 	}, managedAccountObj.authenticationObj.ExponentialBackOff)
 	if technicalError != nil {
@@ -464,11 +532,17 @@ func (managedAccountObj *ManagedAccountstObj) sendRequestAndGetSingleString(http
 
 // DeleteManagedAccountById deletes a managed account by its ID.
 func (managedAccountObj *ManagedAccountstObj) DeleteManagedAccountById(managedAccountID int) error {
+	return managedAccountObj.DeleteManagedAccountByIdWithContext(context.Background(), managedAccountID)
+}
+
+// DeleteManagedAccountByIdWithContext deletes a managed account by its ID.
+func (managedAccountObj *ManagedAccountstObj) DeleteManagedAccountByIdWithContext(ctx context.Context, managedAccountID int) error {
 	url := managedAccountObj.authenticationObj.ApiUrl.JoinPath("ManagedAccounts", strconv.Itoa(managedAccountID)).String()
 	messageLog := fmt.Sprintf("%v %v", "DELETE", url)
 	managedAccountObj.log.Debug(messageLog)
 
 	callSecretSafeAPIObj := &entities.CallSecretSafeAPIObj{
+		Ctx:         ctx,
 		Url:         url,
 		HttpMethod:  "DELETE",
 		Body:        bytes.Buffer{},
@@ -483,7 +557,7 @@ func (managedAccountObj *ManagedAccountstObj) DeleteManagedAccountById(managedAc
 	var businessError error
 
 	technicalError = backoff.Retry(func() error {
-		_, _, technicalError, businessError = managedAccountObj.authenticationObj.HttpClient.CallSecretSafeAPI(*callSecretSafeAPIObj)
+		_, _, technicalError, businessError = managedAccountObj.authenticationObj.HttpClient.CallSecretSafeAPIWithContext(ctx, *callSecretSafeAPIObj)
 		return technicalError
 	}, managedAccountObj.authenticationObj.ExponentialBackOff)
 

--- a/api/managed_systems/managed_systems.go
+++ b/api/managed_systems/managed_systems.go
@@ -4,6 +4,7 @@ package managed_systems
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -34,6 +35,11 @@ func NewManagedSystem(authentication authentication.AuthenticationObj, logger lo
 
 // CreateManagedSystemByAssetIdFlow is responsible for creating managed_systems by Asset Id in Password Safe.
 func (ManagedSystemObj *ManagedSystemObj) CreateManagedSystemByAssetIdFlow(assetId string, managedSystemDetailsInterface interface{}) (entities.ManagedSystemResponseCreate, error) {
+	return ManagedSystemObj.CreateManagedSystemByAssetIdFlowWithContext(context.Background(), assetId, managedSystemDetailsInterface)
+}
+
+// CreateManagedSystemByAssetIdFlowWithContext is responsible for creating managed_systems by Asset Id in Password Safe.
+func (ManagedSystemObj *ManagedSystemObj) CreateManagedSystemByAssetIdFlowWithContext(ctx context.Context, assetId string, managedSystemDetailsInterface interface{}) (entities.ManagedSystemResponseCreate, error) {
 
 	var managedSystemResponse entities.ManagedSystemResponseCreate
 	var managedSystemJson string
@@ -66,7 +72,7 @@ func (ManagedSystemObj *ManagedSystemObj) CreateManagedSystemByAssetIdFlow(asset
 
 	path := fmt.Sprintf("/Assets/%s/ManagedSystems", assetId)
 
-	managedSystemResponse, err = ManagedSystemObj.createManagedSystem(constants.CreateManagedSystemByAssetId, path, managedSystemJson)
+	managedSystemResponse, err = ManagedSystemObj.createManagedSystem(ctx, constants.CreateManagedSystemByAssetId, path, managedSystemJson)
 
 	if err != nil {
 		return managedSystemResponse, err
@@ -78,6 +84,11 @@ func (ManagedSystemObj *ManagedSystemObj) CreateManagedSystemByAssetIdFlow(asset
 
 // CreateManagedSystemByWorkGroupIdFlow is responsible for creating managed_systems by WorkGroup Id in Password Safe.
 func (ManagedSystemObj *ManagedSystemObj) CreateManagedSystemByWorkGroupIdFlow(workGroupId string, managedSystemDetailsInterface interface{}) (entities.ManagedSystemResponseCreate, error) {
+	return ManagedSystemObj.CreateManagedSystemByWorkGroupIdFlowWithContext(context.Background(), workGroupId, managedSystemDetailsInterface)
+}
+
+// CreateManagedSystemByWorkGroupIdFlowWithContext is responsible for creating managed_systems by WorkGroup Id in Password Safe.
+func (ManagedSystemObj *ManagedSystemObj) CreateManagedSystemByWorkGroupIdFlowWithContext(ctx context.Context, workGroupId string, managedSystemDetailsInterface interface{}) (entities.ManagedSystemResponseCreate, error) {
 
 	var managedSystemResponse entities.ManagedSystemResponseCreate
 	var managedSystemJson string
@@ -110,7 +121,7 @@ func (ManagedSystemObj *ManagedSystemObj) CreateManagedSystemByWorkGroupIdFlow(w
 	}
 
 	path := fmt.Sprintf("/Workgroups/%s/ManagedSystems", workGroupId)
-	managedSystemResponse, err = ManagedSystemObj.createManagedSystem(constants.CreateManagedSystemByWorkGroupId, path, managedSystemJson)
+	managedSystemResponse, err = ManagedSystemObj.createManagedSystem(ctx, constants.CreateManagedSystemByWorkGroupId, path, managedSystemJson)
 
 	if err != nil {
 		return managedSystemResponse, err
@@ -122,6 +133,11 @@ func (ManagedSystemObj *ManagedSystemObj) CreateManagedSystemByWorkGroupIdFlow(w
 
 // CreateManagedSystemByDataBaseIdFlow is responsible for creating managed_systems by Database Id in Password Safe.
 func (ManagedSystemObj *ManagedSystemObj) CreateManagedSystemByDataBaseIdFlow(workGroupId string, managedSystemDetailsInterface interface{}) (entities.ManagedSystemResponseCreate, error) {
+	return ManagedSystemObj.CreateManagedSystemByDataBaseIdFlowWithContext(context.Background(), workGroupId, managedSystemDetailsInterface)
+}
+
+// CreateManagedSystemByDataBaseIdFlowWithContext is responsible for creating managed_systems by Database Id in Password Safe.
+func (ManagedSystemObj *ManagedSystemObj) CreateManagedSystemByDataBaseIdFlowWithContext(ctx context.Context, workGroupId string, managedSystemDetailsInterface interface{}) (entities.ManagedSystemResponseCreate, error) {
 
 	var managedSystemResponse entities.ManagedSystemResponseCreate
 	var managedSystemJson string
@@ -150,7 +166,7 @@ func (ManagedSystemObj *ManagedSystemObj) CreateManagedSystemByDataBaseIdFlow(wo
 	}
 
 	path := fmt.Sprintf("/Databases/%s/ManagedSystems", workGroupId)
-	managedSystemResponse, err = ManagedSystemObj.createManagedSystem(constants.CreateManagedSystemByDataBaseId, path, managedSystemJson)
+	managedSystemResponse, err = ManagedSystemObj.createManagedSystem(ctx, constants.CreateManagedSystemByDataBaseId, path, managedSystemJson)
 
 	if err != nil {
 		return managedSystemResponse, err
@@ -161,7 +177,7 @@ func (ManagedSystemObj *ManagedSystemObj) CreateManagedSystemByDataBaseIdFlow(wo
 }
 
 // createManagedSystem calls Password Safe API enpoint to create managed_systems.
-func (ManagedSystemObj *ManagedSystemObj) createManagedSystem(method string, path string, payload string) (entities.ManagedSystemResponseCreate, error) {
+func (ManagedSystemObj *ManagedSystemObj) createManagedSystem(ctx context.Context, method string, path string, payload string) (entities.ManagedSystemResponseCreate, error) {
 
 	var managedSystemResponse entities.ManagedSystemResponseCreate
 
@@ -176,6 +192,7 @@ func (ManagedSystemObj *ManagedSystemObj) createManagedSystem(method string, pat
 	var businessError error
 
 	callSecretSafeAPIObj := &entities.CallSecretSafeAPIObj{
+		Ctx:         ctx,
 		Url:         createManagedSystemUrl,
 		HttpMethod:  "POST",
 		Body:        *b,
@@ -187,7 +204,7 @@ func (ManagedSystemObj *ManagedSystemObj) createManagedSystem(method string, pat
 	}
 
 	technicalError = backoff.Retry(func() error {
-		body, _, technicalError, businessError = ManagedSystemObj.authenticationObj.HttpClient.CallSecretSafeAPI(*callSecretSafeAPIObj)
+		body, _, technicalError, businessError = ManagedSystemObj.authenticationObj.HttpClient.CallSecretSafeAPIWithContext(ctx, *callSecretSafeAPIObj)
 		return technicalError
 	}, ManagedSystemObj.authenticationObj.ExponentialBackOff)
 
@@ -219,12 +236,23 @@ func (ManagedSystemObj *ManagedSystemObj) createManagedSystem(method string, pat
 
 // GetManagedSystemsListFlow get managed system list.
 func (ManagedSystemObj *ManagedSystemObj) GetManagedSystemsListFlow() ([]entities.ManagedSystemResponseCreate, error) {
-	return ManagedSystemObj.GetManagedSystemsList("ManagedSystems", constants.GetManagedSystemsList)
+	return ManagedSystemObj.GetManagedSystemsListFlowWithContext(context.Background())
+}
+
+// GetManagedSystemsListFlowWithContext gets managed system list.
+func (ManagedSystemObj *ManagedSystemObj) GetManagedSystemsListFlowWithContext(ctx context.Context) ([]entities.ManagedSystemResponseCreate, error) {
+	return ManagedSystemObj.GetManagedSystemsListWithContext(ctx, "ManagedSystems", constants.GetManagedSystemsList)
 }
 
 // GetManagedSystemsList call ManagedSystems enpoint
 // and returns managed system list
 func (ManagedSystemObj *ManagedSystemObj) GetManagedSystemsList(endpointPath string, method string) ([]entities.ManagedSystemResponseCreate, error) {
+	return ManagedSystemObj.GetManagedSystemsListWithContext(context.Background(), endpointPath, method)
+}
+
+// GetManagedSystemsListWithContext calls ManagedSystems endpoint
+// and returns managed system list
+func (ManagedSystemObj *ManagedSystemObj) GetManagedSystemsListWithContext(ctx context.Context, endpointPath string, method string) ([]entities.ManagedSystemResponseCreate, error) {
 	messageLog := fmt.Sprintf("%v %v", "GET", endpointPath)
 	ManagedSystemObj.log.Debug(messageLog + endpointPath)
 
@@ -232,7 +260,7 @@ func (ManagedSystemObj *ManagedSystemObj) GetManagedSystemsList(endpointPath str
 
 	var managedSystemsList []entities.ManagedSystemResponseCreate
 
-	response, err := ManagedSystemObj.authenticationObj.HttpClient.GetGeneralList(url, ManagedSystemObj.authenticationObj.ApiVersion, method, ManagedSystemObj.authenticationObj.ExponentialBackOff)
+	response, err := ManagedSystemObj.authenticationObj.HttpClient.GetGeneralListWithContext(ctx, url, ManagedSystemObj.authenticationObj.ApiVersion, method, ManagedSystemObj.authenticationObj.ExponentialBackOff)
 
 	if err != nil {
 		return managedSystemsList, err
@@ -254,10 +282,16 @@ func (ManagedSystemObj *ManagedSystemObj) GetManagedSystemsList(endpointPath str
 
 // DeleteManagedSystemById deletes a managed system by its ID.
 func (managedSystemObj *ManagedSystemObj) DeleteManagedSystemById(managedSystemID int) error {
+	return managedSystemObj.DeleteManagedSystemByIdWithContext(context.Background(), managedSystemID)
+}
+
+// DeleteManagedSystemByIdWithContext deletes a managed system by its ID.
+func (managedSystemObj *ManagedSystemObj) DeleteManagedSystemByIdWithContext(ctx context.Context, managedSystemID int) error {
 	urlBuilder := func(id string) string {
 		return managedSystemObj.authenticationObj.ApiUrl.JoinPath("ManagedSystems", id).String()
 	}
-	return utils.DeleteResourceByID(
+	return utils.DeleteResourceByIDWithContext(
+		ctx,
 		fmt.Sprintf("%d", managedSystemID),
 		"managed system",
 		constants.DeleteManagedSystem,

--- a/api/platforms/platforms.go
+++ b/api/platforms/platforms.go
@@ -3,6 +3,7 @@
 package platforms
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 
@@ -29,12 +30,23 @@ func NewPlatformObj(authentication authentication.AuthenticationObj, logger logg
 
 // GetPlatformsListFlow get platforms list.
 func (platformObj *PlatformObj) GetPlatformsListFlow() ([]entities.PlatformResponse, error) {
-	return platformObj.GetPlatformsList("Platforms", constants.GetPlatformsList)
+	return platformObj.GetPlatformsListFlowWithContext(context.Background())
+}
+
+// GetPlatformsListFlowWithContext gets platforms list.
+func (platformObj *PlatformObj) GetPlatformsListFlowWithContext(ctx context.Context) ([]entities.PlatformResponse, error) {
+	return platformObj.GetPlatformsListWithContext(ctx, "Platforms", constants.GetPlatformsList)
 }
 
 // GetPlatformsList call Platforms enpoint
 // and returns platforms list
 func (platformObj *PlatformObj) GetPlatformsList(endpointPath string, method string) ([]entities.PlatformResponse, error) {
+	return platformObj.GetPlatformsListWithContext(context.Background(), endpointPath, method)
+}
+
+// GetPlatformsListWithContext calls Platforms endpoint
+// and returns platforms list
+func (platformObj *PlatformObj) GetPlatformsListWithContext(ctx context.Context, endpointPath string, method string) ([]entities.PlatformResponse, error) {
 	messageLog := fmt.Sprintf("%v %v", "GET", endpointPath)
 	platformObj.log.Debug(messageLog + endpointPath)
 
@@ -42,7 +54,7 @@ func (platformObj *PlatformObj) GetPlatformsList(endpointPath string, method str
 
 	var platformsList []entities.PlatformResponse
 
-	response, err := platformObj.authenticationObj.HttpClient.GetGeneralList(url, platformObj.authenticationObj.ApiVersion, method, platformObj.authenticationObj.ExponentialBackOff)
+	response, err := platformObj.authenticationObj.HttpClient.GetGeneralListWithContext(ctx, url, platformObj.authenticationObj.ApiVersion, method, platformObj.authenticationObj.ExponentialBackOff)
 
 	if err != nil {
 		return platformsList, err

--- a/api/secrets/secrets.go
+++ b/api/secrets/secrets.go
@@ -4,6 +4,7 @@ package secrets
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -42,20 +43,35 @@ func NewSecretObj(authentication authentication.AuthenticationObj, logger loggin
 
 // GetSecrets returns secret value for a path and title list.
 func (secretObj *SecretObj) GetSecrets(secretPaths []string, separator string) (map[string]string, error) {
-	return secretObj.GetSecretFlow(secretPaths, separator)
+	return secretObj.GetSecretsWithContext(context.Background(), secretPaths, separator)
+}
+
+// GetSecretsWithContext returns secret value for a path and title list.
+func (secretObj *SecretObj) GetSecretsWithContext(ctx context.Context, secretPaths []string, separator string) (map[string]string, error) {
+	return secretObj.GetSecretFlowWithContext(ctx, secretPaths, separator)
 }
 
 // GetSecret returns secret value for a specific path and title.
 func (secretObj *SecretObj) GetSecret(secretPath string, separator string) (string, error) {
+	return secretObj.GetSecretWithContext(context.Background(), secretPath, separator)
+}
+
+// GetSecretWithContext returns secret value for a specific path and title.
+func (secretObj *SecretObj) GetSecretWithContext(ctx context.Context, secretPath string, separator string) (string, error) {
 	secretPaths := []string{}
-	secrets, err := secretObj.GetSecretFlow(append(secretPaths, secretPath), separator)
+	secrets, err := secretObj.GetSecretFlowWithContext(ctx, append(secretPaths, secretPath), separator)
 	secretValue := secrets[secretPath]
 	return secretValue, err
 }
 
 // GetFileSecret Get data of a file secret.
 func (secretObj *SecretObj) GetFileSecret(secret entities.Secret, secretPath string) (string, error) {
-	fileSecretContent, err := secretObj.SecretGetFileSecret(secret.Id, "secrets-safe/secrets/")
+	return secretObj.GetFileSecretWithContext(context.Background(), secret, secretPath)
+}
+
+// GetFileSecretWithContext gets data of a file secret.
+func (secretObj *SecretObj) GetFileSecretWithContext(ctx context.Context, secret entities.Secret, secretPath string) (string, error) {
+	fileSecretContent, err := secretObj.SecretGetFileSecretWithContext(ctx, secret.Id, "secrets-safe/secrets/")
 	if err != nil {
 		return "", err
 	}
@@ -71,9 +87,14 @@ func (secretObj *SecretObj) GetFileSecret(secret entities.Secret, secretPath str
 
 // GetGeneralSecret Get general data of a secret.
 func (secretObj *SecretObj) GetGeneralSecret(secretPath string, secretTitle string, separator string) (entities.Secret, error) {
+	return secretObj.GetGeneralSecretWithContext(context.Background(), secretPath, secretTitle, separator)
+}
+
+// GetGeneralSecretWithContext gets general data of a secret.
+func (secretObj *SecretObj) GetGeneralSecretWithContext(ctx context.Context, secretPath string, secretTitle string, separator string) (entities.Secret, error) {
 
 	var err error
-	secret, err := secretObj.SecretGetSecretByPath(secretPath, secretTitle, separator, "secrets-safe/secrets")
+	secret, err := secretObj.SecretGetSecretByPathWithContext(ctx, secretPath, secretTitle, separator, "secrets-safe/secrets")
 
 	entireSecretPath := secretPath + separator + secretTitle
 
@@ -100,6 +121,11 @@ func (secretObj *SecretObj) SplitGetSecretPathAndSecretTitle(secretToRetrieve st
 
 // GetSecretFlow is responsible for creating a dictionary of secrets safe secret paths and secret key-value pairs.
 func (secretObj *SecretObj) GetSecretFlow(secretsToRetrieve []string, separator string) (map[string]string, error) {
+	return secretObj.GetSecretFlowWithContext(context.Background(), secretsToRetrieve, separator)
+}
+
+// GetSecretFlowWithContext is responsible for creating a dictionary of secrets safe secret paths and secret key-value pairs.
+func (secretObj *SecretObj) GetSecretFlowWithContext(ctx context.Context, secretsToRetrieve []string, separator string) (map[string]string, error) {
 
 	secretsToRetrieve = utils.ValidatePaths(secretsToRetrieve, false, separator, secretObj.log)
 	secretObj.log.Info(fmt.Sprintf("Retrieving %v Secrets", len(secretsToRetrieve)))
@@ -115,7 +141,7 @@ func (secretObj *SecretObj) GetSecretFlow(secretsToRetrieve []string, separator 
 		secretPath, secretTitle := secretObj.SplitGetSecretPathAndSecretTitle(secretToRetrieve, separator)
 		entireSecretPath := secretPath + separator + secretTitle
 
-		secret, err := secretObj.GetGeneralSecret(secretPath, secretTitle, separator)
+		secret, err := secretObj.GetGeneralSecretWithContext(ctx, secretPath, secretTitle, separator)
 
 		if err != nil {
 			saveLastErr = err
@@ -125,7 +151,7 @@ func (secretObj *SecretObj) GetSecretFlow(secretsToRetrieve []string, separator 
 
 		// When secret type is FILE, it calls SecretGetFileSecret method.
 		if strings.ToUpper(secret.SecretType) == "FILE" {
-			fileSecretContent, err := secretObj.GetFileSecret(secret, entireSecretPath)
+			fileSecretContent, err := secretObj.GetFileSecretWithContext(ctx, secret, entireSecretPath)
 			if err != nil {
 				saveLastErr = err
 				secretObj.log.Error(err.Error() + "secretPath:" + entireSecretPath)
@@ -143,6 +169,11 @@ func (secretObj *SecretObj) GetSecretFlow(secretsToRetrieve []string, separator 
 
 // SecretGetSecretByPath returns secret object for a specific path, title.
 func (secretObj *SecretObj) SecretGetSecretByPath(secretPath string, secretTitle string, separator string, endpointPath string) (entities.Secret, error) {
+	return secretObj.SecretGetSecretByPathWithContext(context.Background(), secretPath, secretTitle, separator, endpointPath)
+}
+
+// SecretGetSecretByPathWithContext returns secret object for a specific path, title.
+func (secretObj *SecretObj) SecretGetSecretByPathWithContext(ctx context.Context, secretPath string, secretTitle string, separator string, endpointPath string) (entities.Secret, error) {
 
 	var body io.ReadCloser
 	var technicalError error
@@ -170,6 +201,7 @@ func (secretObj *SecretObj) SecretGetSecretByPath(secretPath string, secretTitle
 	secretObj.log.Debug(messageLog)
 
 	callSecretSafeAPIObj := &entities.CallSecretSafeAPIObj{
+		Ctx:         ctx,
 		Url:         endpointUrl,
 		HttpMethod:  "GET",
 		Body:        bytes.Buffer{},
@@ -181,7 +213,7 @@ func (secretObj *SecretObj) SecretGetSecretByPath(secretPath string, secretTitle
 	}
 
 	technicalError = backoff.Retry(func() error {
-		body, scode, technicalError, businessError = secretObj.authenticationObj.HttpClient.CallSecretSafeAPI(*callSecretSafeAPIObj)
+		body, scode, technicalError, businessError = secretObj.authenticationObj.HttpClient.CallSecretSafeAPIWithContext(ctx, *callSecretSafeAPIObj)
 		return technicalError
 	}, secretObj.authenticationObj.ExponentialBackOff)
 
@@ -218,6 +250,12 @@ func (secretObj *SecretObj) SecretGetSecretByPath(secretPath string, secretTitle
 // SecretGetFileSecret call secrets-safe/secrets/<secret_id>/file/download enpoint
 // and returns file secret value.
 func (secretObj *SecretObj) SecretGetFileSecret(secretId string, endpointPath string) (string, error) {
+	return secretObj.SecretGetFileSecretWithContext(context.Background(), secretId, endpointPath)
+}
+
+// SecretGetFileSecretWithContext calls secrets-safe/secrets/<secret_id>/file/download endpoint
+// and returns file secret value.
+func (secretObj *SecretObj) SecretGetFileSecretWithContext(ctx context.Context, secretId string, endpointPath string) (string, error) {
 
 	var body io.ReadCloser
 	var technicalError error
@@ -229,6 +267,7 @@ func (secretObj *SecretObj) SecretGetFileSecret(secretId string, endpointPath st
 	secretObj.log.Debug(messageLog)
 
 	callSecretSafeAPIObj := &entities.CallSecretSafeAPIObj{
+		Ctx:         ctx,
 		Url:         url,
 		HttpMethod:  "GET",
 		Body:        bytes.Buffer{},
@@ -240,7 +279,7 @@ func (secretObj *SecretObj) SecretGetFileSecret(secretId string, endpointPath st
 	}
 
 	technicalError = backoff.Retry(func() error {
-		body, _, technicalError, businessError = secretObj.authenticationObj.HttpClient.CallSecretSafeAPI(*callSecretSafeAPIObj)
+		body, _, technicalError, businessError = secretObj.authenticationObj.HttpClient.CallSecretSafeAPIWithContext(ctx, *callSecretSafeAPIObj)
 		return technicalError
 	}, secretObj.authenticationObj.ExponentialBackOff)
 
@@ -269,6 +308,11 @@ func (secretObj *SecretObj) SecretGetFileSecret(secretId string, endpointPath st
 // is selected here based on the authenticated API version — or a Config30/Config31
 // directly, which is passed through unchanged for backward compatibility.
 func (secretObj *SecretObj) CreateSecretFlow(folderTarget string, secretDetails interface{}) (entities.CreateSecretResponse, error) {
+	return secretObj.CreateSecretFlowWithContext(context.Background(), folderTarget, secretDetails)
+}
+
+// CreateSecretFlowWithContext is responsible for creating secrets in Password Safe.
+func (secretObj *SecretObj) CreateSecretFlowWithContext(ctx context.Context, folderTarget string, secretDetails interface{}) (entities.CreateSecretResponse, error) {
 
 	var folder *entities.FolderResponse
 	var createResponse entities.CreateSecretResponse
@@ -295,7 +339,7 @@ func (secretObj *SecretObj) CreateSecretFlow(folderTarget string, secretDetails 
 		return createResponse, err
 	}
 
-	folders, err := secretObj.SecretGetFoldersAndSafes("secrets-safe/folders/", constants.SecretGetFolders)
+	folders, err := secretObj.SecretGetFoldersAndSafesWithContext(ctx, "secrets-safe/folders/", constants.SecretGetFolders)
 
 	if err != nil {
 		return createResponse, err
@@ -312,7 +356,7 @@ func (secretObj *SecretObj) CreateSecretFlow(folderTarget string, secretDetails 
 		return createResponse, fmt.Errorf("folder %v was not found in folder list", folderTarget)
 	}
 
-	createResponse, err = secretObj.SecretCreateSecret(folder.Id, secretDetails)
+	createResponse, err = secretObj.SecretCreateSecretWithContext(ctx, folder.Id, secretDetails)
 
 	if err != nil {
 		return createResponse, err
@@ -426,6 +470,11 @@ func decodeSecretListResponse(body []byte) ([]entities.Secret, error) {
 
 // SecretCreateFileSecret create a secret of type file.
 func (secretObj *SecretObj) SecretCreateFileSecret(SecretCreateSecretUrl string, payload string, secretDetails interface{}) (entities.CreateSecretResponse, error) {
+	return secretObj.SecretCreateFileSecretWithContext(context.Background(), SecretCreateSecretUrl, payload, secretDetails)
+}
+
+// SecretCreateFileSecretWithContext creates a secret of type file.
+func (secretObj *SecretObj) SecretCreateFileSecretWithContext(ctx context.Context, SecretCreateSecretUrl string, payload string, secretDetails interface{}) (entities.CreateSecretResponse, error) {
 
 	var fileName string
 	var fileContent string
@@ -444,7 +493,7 @@ func (secretObj *SecretObj) SecretCreateFileSecret(SecretCreateSecretUrl string,
 		fileContent = fileSecret.FileContent
 	}
 
-	body, err := secretObj.authenticationObj.HttpClient.CreateMultiPartRequest(SecretCreateSecretUrl, fileName, []byte(payload), fileContent, secretObj.authenticationObj.ApiVersion)
+	body, err := secretObj.authenticationObj.HttpClient.CreateMultiPartRequestWithContext(ctx, SecretCreateSecretUrl, fileName, []byte(payload), fileContent, secretObj.authenticationObj.ApiVersion)
 	if err != nil {
 		return entities.CreateSecretResponse{}, err
 	}
@@ -468,6 +517,11 @@ func (secretObj *SecretObj) SecretCreateFileSecret(SecretCreateSecretUrl string,
 
 // SecretCreateSecret calls Secret Safe API Requests enpoint to create secrets in Password Safe.
 func (secretObj *SecretObj) SecretCreateSecret(folderId string, secretDetails interface{}) (entities.CreateSecretResponse, error) {
+	return secretObj.SecretCreateSecretWithContext(context.Background(), folderId, secretDetails)
+}
+
+// SecretCreateSecretWithContext calls Secret Safe API Requests endpoint to create secrets in Password Safe.
+func (secretObj *SecretObj) SecretCreateSecretWithContext(ctx context.Context, folderId string, secretDetails interface{}) (entities.CreateSecretResponse, error) {
 
 	var CreateSecretResponse entities.CreateSecretResponse
 	var secretCredentialDetailsJson string
@@ -494,7 +548,7 @@ func (secretObj *SecretObj) SecretCreateSecret(folderId string, secretDetails in
 
 	// file secrets have a special behavior, they need to be created using multipart request.
 	if path == "secrets/file" {
-		return secretObj.SecretCreateFileSecret(SecretCreateSecretUrl, payload, secretDetails)
+		return secretObj.SecretCreateFileSecretWithContext(ctx, SecretCreateSecretUrl, payload, secretDetails)
 	}
 
 	var body io.ReadCloser
@@ -502,6 +556,7 @@ func (secretObj *SecretObj) SecretCreateSecret(folderId string, secretDetails in
 	var businessError error
 
 	callSecretSafeAPIObj := &entities.CallSecretSafeAPIObj{
+		Ctx:         ctx,
 		Url:         SecretCreateSecretUrl,
 		HttpMethod:  "POST",
 		Body:        *b,
@@ -513,7 +568,7 @@ func (secretObj *SecretObj) SecretCreateSecret(folderId string, secretDetails in
 	}
 
 	technicalError = backoff.Retry(func() error {
-		body, _, technicalError, businessError = secretObj.authenticationObj.HttpClient.CallSecretSafeAPI(*callSecretSafeAPIObj)
+		body, _, technicalError, businessError = secretObj.authenticationObj.HttpClient.CallSecretSafeAPIWithContext(ctx, *callSecretSafeAPIObj)
 		return technicalError
 	}, secretObj.authenticationObj.ExponentialBackOff)
 
@@ -572,17 +627,32 @@ func (secretObj *SecretObj) GetPathToCreateSecret(secretDetails interface{}) str
 
 // SecretGetFoldersFlow get folders list
 func (secretObj *SecretObj) SecretGetFoldersListFlow() ([]entities.FolderResponse, error) {
-	return secretObj.SecretGetFoldersAndSafes("secrets-safe/folders/", constants.SecretGetFolders)
+	return secretObj.SecretGetFoldersListFlowWithContext(context.Background())
+}
+
+// SecretGetFoldersListFlowWithContext gets folders list.
+func (secretObj *SecretObj) SecretGetFoldersListFlowWithContext(ctx context.Context) ([]entities.FolderResponse, error) {
+	return secretObj.SecretGetFoldersAndSafesWithContext(ctx, "secrets-safe/folders/", constants.SecretGetFolders)
 }
 
 // SecretGetSafesFlow get safes list
 func (secretObj *SecretObj) SecretGetSafesListFlow() ([]entities.FolderResponse, error) {
-	return secretObj.SecretGetFoldersAndSafes("secrets-safe/safes/", constants.SecretGetSafes)
+	return secretObj.SecretGetSafesListFlowWithContext(context.Background())
+}
+
+// SecretGetSafesListFlowWithContext gets safes list.
+func (secretObj *SecretObj) SecretGetSafesListFlowWithContext(ctx context.Context) ([]entities.FolderResponse, error) {
+	return secretObj.SecretGetFoldersAndSafesWithContext(ctx, "secrets-safe/safes/", constants.SecretGetSafes)
 }
 
 // SecretGetFoldersAndSafes call secrets-safe/folders/ - secrets-safe/folders/  enpoint
 // and returns folder list - safe list
 func (secretObj *SecretObj) SecretGetFoldersAndSafes(endpointPath string, method string) ([]entities.FolderResponse, error) {
+	return secretObj.SecretGetFoldersAndSafesWithContext(context.Background(), endpointPath, method)
+}
+
+// SecretGetFoldersAndSafesWithContext calls folder/safe endpoints and returns lists.
+func (secretObj *SecretObj) SecretGetFoldersAndSafesWithContext(ctx context.Context, endpointPath string, method string) ([]entities.FolderResponse, error) {
 	messageLog := fmt.Sprintf("%v %v", "GET", endpointPath)
 	secretObj.log.Debug(messageLog + endpointPath)
 
@@ -591,6 +661,7 @@ func (secretObj *SecretObj) SecretGetFoldersAndSafes(endpointPath string, method
 	var foldersObj []entities.FolderResponse
 
 	callSecretSafeAPIObj := &entities.CallSecretSafeAPIObj{
+		Ctx:         ctx,
 		Url:         url,
 		HttpMethod:  "GET",
 		Body:        bytes.Buffer{},
@@ -601,7 +672,7 @@ func (secretObj *SecretObj) SecretGetFoldersAndSafes(endpointPath string, method
 		ApiVersion:  secretObj.authenticationObj.ApiVersion,
 	}
 
-	response, err := secretObj.authenticationObj.HttpClient.MakeRequest(callSecretSafeAPIObj, secretObj.authenticationObj.ExponentialBackOff)
+	response, err := secretObj.authenticationObj.HttpClient.MakeRequestWithContext(ctx, callSecretSafeAPIObj, secretObj.authenticationObj.ExponentialBackOff)
 
 	if err != nil {
 		secretObj.log.Error(err.Error())
@@ -624,6 +695,11 @@ func (secretObj *SecretObj) SecretGetFoldersAndSafes(endpointPath string, method
 
 // GetParentFolderId Get parent folder id using folder name.
 func (secretObj *SecretObj) GetParentFolderId(folderTarget string) (string, error) {
+	return secretObj.GetParentFolderIdWithContext(context.Background(), folderTarget)
+}
+
+// GetParentFolderIdWithContext gets parent folder id using folder name.
+func (secretObj *SecretObj) GetParentFolderIdWithContext(ctx context.Context, folderTarget string) (string, error) {
 
 	var parentFolder *entities.FolderResponse
 
@@ -631,7 +707,7 @@ func (secretObj *SecretObj) GetParentFolderId(folderTarget string) (string, erro
 		return "", fmt.Errorf("parent folder name must not be empty")
 	}
 
-	folders, err := secretObj.SecretGetFoldersAndSafes("secrets-safe/folders/", constants.SecretGetFolders)
+	folders, err := secretObj.SecretGetFoldersAndSafesWithContext(ctx, "secrets-safe/folders/", constants.SecretGetFolders)
 
 	if err != nil {
 		return "", err
@@ -653,6 +729,11 @@ func (secretObj *SecretObj) GetParentFolderId(folderTarget string) (string, erro
 
 // CreateFolderFlow is responsible for creating folders/safes in Password Safe.
 func (secretObj *SecretObj) CreateFolderFlow(folderTarget string, folderDetails entities.FolderDetails) (entities.CreateFolderResponse, error) {
+	return secretObj.CreateFolderFlowWithContext(context.Background(), folderTarget, folderDetails)
+}
+
+// CreateFolderFlowWithContext is responsible for creating folders/safes in Password Safe.
+func (secretObj *SecretObj) CreateFolderFlowWithContext(ctx context.Context, folderTarget string, folderDetails entities.FolderDetails) (entities.CreateFolderResponse, error) {
 
 	var createFolderesponse entities.CreateFolderResponse
 	var err error
@@ -665,7 +746,7 @@ func (secretObj *SecretObj) CreateFolderFlow(folderTarget string, folderDetails 
 
 	// if it is folder
 	if folderDetails.FolderType == "FOLDER" {
-		parentFolderId, err := secretObj.GetParentFolderId(folderTarget)
+		parentFolderId, err := secretObj.GetParentFolderIdWithContext(ctx, folderTarget)
 		if err != nil {
 			return createFolderesponse, err
 		}
@@ -679,7 +760,7 @@ func (secretObj *SecretObj) CreateFolderFlow(folderTarget string, folderDetails 
 		return createFolderesponse, err
 	}
 
-	createFolderesponse, err = secretObj.SecretCreateFolder(folderDetails)
+	createFolderesponse, err = secretObj.SecretCreateFolderWithContext(ctx, folderDetails)
 
 	if err != nil {
 		return createFolderesponse, err
@@ -690,6 +771,11 @@ func (secretObj *SecretObj) CreateFolderFlow(folderTarget string, folderDetails 
 
 // SecretCreateFolder calls Secret Safe API Requests enpoint to create folders/safes in Password Safe.
 func (secretObj *SecretObj) SecretCreateFolder(folderDetails entities.FolderDetails) (entities.CreateFolderResponse, error) {
+	return secretObj.SecretCreateFolderWithContext(context.Background(), folderDetails)
+}
+
+// SecretCreateFolderWithContext calls Secret Safe API Requests endpoint to create folders/safes in Password Safe.
+func (secretObj *SecretObj) SecretCreateFolderWithContext(ctx context.Context, folderDetails entities.FolderDetails) (entities.CreateFolderResponse, error) {
 
 	path := "secrets-safe/folders/"
 	method := constants.SecretCreateFolder
@@ -719,6 +805,7 @@ func (secretObj *SecretObj) SecretCreateFolder(folderDetails entities.FolderDeta
 	var businessError error
 
 	callSecretSafeAPIObj := &entities.CallSecretSafeAPIObj{
+		Ctx:         ctx,
 		Url:         SecretCreateSecretUrl,
 		HttpMethod:  "POST",
 		Body:        *b,
@@ -730,7 +817,7 @@ func (secretObj *SecretObj) SecretCreateFolder(folderDetails entities.FolderDeta
 	}
 
 	technicalError = backoff.Retry(func() error {
-		body, _, technicalError, businessError = secretObj.authenticationObj.HttpClient.CallSecretSafeAPI(*callSecretSafeAPIObj)
+		body, _, technicalError, businessError = secretObj.authenticationObj.HttpClient.CallSecretSafeAPIWithContext(ctx, *callSecretSafeAPIObj)
 		return technicalError
 	}, secretObj.authenticationObj.ExponentialBackOff)
 
@@ -762,10 +849,16 @@ func (secretObj *SecretObj) SecretCreateFolder(folderDetails entities.FolderDeta
 
 // DeleteSecretById deletes a secret by its ID.
 func (secretObj *SecretObj) DeleteSecretById(secretID string) error {
+	return secretObj.DeleteSecretByIdWithContext(context.Background(), secretID)
+}
+
+// DeleteSecretByIdWithContext deletes a secret by its ID.
+func (secretObj *SecretObj) DeleteSecretByIdWithContext(ctx context.Context, secretID string) error {
 	urlBuilder := func(id string) string {
 		return secretObj.authenticationObj.ApiUrl.JoinPath("secrets-safe/secrets", id).String()
 	}
-	return utils.DeleteResourceByID(
+	return utils.DeleteResourceByIDWithContext(
+		ctx,
 		secretID,
 		"secret",
 		constants.SecretDeleteSecret,
@@ -779,10 +872,16 @@ func (secretObj *SecretObj) DeleteSecretById(secretID string) error {
 
 // DeleteFolderById deletes a folder by its ID.
 func (secretObj *SecretObj) DeleteFolderById(folderID string) error {
+	return secretObj.DeleteFolderByIdWithContext(context.Background(), folderID)
+}
+
+// DeleteFolderByIdWithContext deletes a folder by its ID.
+func (secretObj *SecretObj) DeleteFolderByIdWithContext(ctx context.Context, folderID string) error {
 	urlBuilder := func(id string) string {
 		return secretObj.authenticationObj.ApiUrl.JoinPath("secrets-safe/folders", id).String()
 	}
-	return utils.DeleteResourceByID(
+	return utils.DeleteResourceByIDWithContext(
+		ctx,
 		folderID,
 		"folder",
 		constants.SecretDeleteFolder,
@@ -796,10 +895,16 @@ func (secretObj *SecretObj) DeleteFolderById(folderID string) error {
 
 // DeleteSafeById deletes a safe by its ID.
 func (secretObj *SecretObj) DeleteSafeById(safeID string) error {
+	return secretObj.DeleteSafeByIdWithContext(context.Background(), safeID)
+}
+
+// DeleteSafeByIdWithContext deletes a safe by its ID.
+func (secretObj *SecretObj) DeleteSafeByIdWithContext(ctx context.Context, safeID string) error {
 	urlBuilder := func(id string) string {
 		return secretObj.authenticationObj.ApiUrl.JoinPath("secrets-safe/safes", id).String()
 	}
-	return utils.DeleteResourceByID(
+	return utils.DeleteResourceByIDWithContext(
+		ctx,
 		safeID,
 		"safe",
 		constants.SecretDeleteSafe,
@@ -813,8 +918,13 @@ func (secretObj *SecretObj) DeleteSafeById(safeID string) error {
 
 // SearchSecretByTitleFlow calls Password Safe API endpoint to search secrets by title.
 func (secretObj *SecretObj) SearchSecretByTitleFlow(secretTitle string) (entities.Secret, error) {
+	return secretObj.SearchSecretByTitleFlowWithContext(context.Background(), secretTitle)
+}
+
+// SearchSecretByTitleFlowWithContext calls Password Safe API endpoint to search secrets by title.
+func (secretObj *SecretObj) SearchSecretByTitleFlowWithContext(ctx context.Context, secretTitle string) (entities.Secret, error) {
 	var secretResponse []entities.Secret
-	secretResponse, err := secretObj.SearchSecretByTitle("secrets-safe/secrets", secretTitle)
+	secretResponse, err := secretObj.SearchSecretByTitleWithContext(ctx, "secrets-safe/secrets", secretTitle)
 	if err != nil {
 		return entities.Secret{}, err
 	}
@@ -827,6 +937,11 @@ func (secretObj *SecretObj) SearchSecretByTitleFlow(secretTitle string) (entitie
 
 // SearchSecretByTitle calls secrets-safe/secrets endpoint
 func (secretObj *SecretObj) SearchSecretByTitle(endpointPath string, title string) ([]entities.Secret, error) {
+	return secretObj.SearchSecretByTitleWithContext(context.Background(), endpointPath, title)
+}
+
+// SearchSecretByTitleWithContext calls secrets-safe/secrets endpoint.
+func (secretObj *SecretObj) SearchSecretByTitleWithContext(ctx context.Context, endpointPath string, title string) ([]entities.Secret, error) {
 
 	var secretResponse []entities.Secret
 
@@ -849,6 +964,7 @@ func (secretObj *SecretObj) SearchSecretByTitle(endpointPath string, title strin
 	secretObj.log.Debug(messageLog)
 
 	callSecretSafeAPIObj := &entities.CallSecretSafeAPIObj{
+		Ctx:         ctx,
 		Url:         endpointUrl,
 		HttpMethod:  "GET",
 		Body:        bytes.Buffer{},
@@ -859,7 +975,7 @@ func (secretObj *SecretObj) SearchSecretByTitle(endpointPath string, title strin
 		ApiVersion:  "",
 	}
 
-	response, err := secretObj.authenticationObj.HttpClient.MakeRequest(callSecretSafeAPIObj, secretObj.authenticationObj.ExponentialBackOff)
+	response, err := secretObj.authenticationObj.HttpClient.MakeRequestWithContext(ctx, callSecretSafeAPIObj, secretObj.authenticationObj.ExponentialBackOff)
 
 	if err != nil {
 		return secretResponse, err

--- a/api/session/session.go
+++ b/api/session/session.go
@@ -108,7 +108,7 @@ func NewSessionFromToken(ctx context.Context, accessToken string, params Paramet
 	}
 
 	signInURL := authObj.ApiUrl.JoinPath("Auth/SignAppIn").String()
-	_, err = authObj.SignAppin(signInURL, accessToken, "")
+	_, err = authObj.SignAppinWithContext(ctx, signInURL, accessToken, "")
 	if err != nil {
 		return nil, fmt.Errorf("session: SignAppin failed: %w", err)
 	}
@@ -133,25 +133,50 @@ func NewSessionFromToken(ctx context.Context, accessToken string, params Paramet
 
 // GetSecret returns the secret value for a single Secrets Safe path.
 func (s *Session) GetSecret(secretPath string, separator string) (string, error) {
-	return s.secretObj.GetSecret(secretPath, separator)
+	return s.GetSecretWithContext(context.Background(), secretPath, separator)
+}
+
+// GetSecretWithContext returns the secret value for a single Secrets Safe path.
+func (s *Session) GetSecretWithContext(ctx context.Context, secretPath string, separator string) (string, error) {
+	return s.secretObj.GetSecretWithContext(ctx, secretPath, separator)
 }
 
 // GetSecrets returns secret values for a list of Secrets Safe paths.
 func (s *Session) GetSecrets(secretPaths []string, separator string) (map[string]string, error) {
-	return s.secretObj.GetSecrets(secretPaths, separator)
+	return s.GetSecretsWithContext(context.Background(), secretPaths, separator)
+}
+
+// GetSecretsWithContext returns secret values for a list of Secrets Safe paths.
+func (s *Session) GetSecretsWithContext(ctx context.Context, secretPaths []string, separator string) (map[string]string, error) {
+	return s.secretObj.GetSecretsWithContext(ctx, secretPaths, separator)
 }
 
 // GetManagedAccount returns the password for a single managed account.
 func (s *Session) GetManagedAccount(secretPath string, separator string) (string, error) {
-	return s.maObj.GetSecret(secretPath, separator)
+	return s.GetManagedAccountWithContext(context.Background(), secretPath, separator)
+}
+
+// GetManagedAccountWithContext returns the password for a single managed account.
+func (s *Session) GetManagedAccountWithContext(ctx context.Context, secretPath string, separator string) (string, error) {
+	return s.maObj.GetSecretWithContext(ctx, secretPath, separator)
 }
 
 // GetManagedAccounts returns passwords for a list of managed accounts.
 func (s *Session) GetManagedAccounts(secretPaths []string, separator string) (map[string]string, error) {
-	return s.maObj.GetSecrets(secretPaths, separator)
+	return s.GetManagedAccountsWithContext(context.Background(), secretPaths, separator)
+}
+
+// GetManagedAccountsWithContext returns passwords for a list of managed accounts.
+func (s *Session) GetManagedAccountsWithContext(ctx context.Context, secretPaths []string, separator string) (map[string]string, error) {
+	return s.maObj.GetSecretsWithContext(ctx, secretPaths, separator)
 }
 
 // Close signs out of the BeyondTrust API session.
 func (s *Session) Close() error {
-	return s.authObj.SignOut()
+	return s.CloseWithContext(context.Background())
+}
+
+// CloseWithContext signs out of the BeyondTrust API session.
+func (s *Session) CloseWithContext(ctx context.Context) error {
+	return s.authObj.SignOutWithContext(ctx)
 }

--- a/api/utils/common.go
+++ b/api/utils/common.go
@@ -4,6 +4,7 @@ package utils
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"strconv"
 
@@ -43,6 +44,21 @@ func DeleteResourceByID(
 	exponentialBackOff *backoff.ExponentialBackOff,
 	logger logging.Logger,
 ) error {
+	return DeleteResourceByIDWithContext(context.Background(), resourceID, resourceType, methodConstant, urlBuilder, validateAsUUID, httpClient, exponentialBackOff, logger)
+}
+
+// DeleteResourceByIDWithContext is a reusable function for deleting resources by ID with context.
+func DeleteResourceByIDWithContext(
+	ctx context.Context,
+	resourceID string,
+	resourceType string,
+	methodConstant string,
+	urlBuilder func(id string) string,
+	validateAsUUID bool,
+	httpClient *HttpClientObj,
+	exponentialBackOff *backoff.ExponentialBackOff,
+	logger logging.Logger,
+) error {
 	// Validate ID format based on requirements
 	err := validateResourceID(resourceID, resourceType, validateAsUUID)
 	if err != nil {
@@ -54,6 +70,7 @@ func DeleteResourceByID(
 	logger.Debug(messageLog)
 
 	callSecretSafeAPIObj := &entities.CallSecretSafeAPIObj{
+		Ctx:         ctx,
 		Url:         url,
 		HttpMethod:  "DELETE",
 		Body:        bytes.Buffer{},
@@ -68,7 +85,7 @@ func DeleteResourceByID(
 	var businessError error
 
 	technicalError = backoff.Retry(func() error {
-		_, _, technicalError, businessError = httpClient.CallSecretSafeAPI(*callSecretSafeAPIObj)
+		_, _, technicalError, businessError = httpClient.CallSecretSafeAPIWithContext(ctx, *callSecretSafeAPIObj)
 		return technicalError
 	}, exponentialBackOff)
 
@@ -80,7 +97,6 @@ func DeleteResourceByID(
 	}
 	return nil
 }
-
 
 // GetOwnerDetailsOwnerIdList get Owners details list.
 func GetOwnerDetailsOwnerIdList(data map[string]interface{}, signAppinResponse entities.SignAppinResponse) []entities.OwnerDetailsOwnerId {
@@ -119,7 +135,6 @@ func GetOwnerDetailsOwnerIdList(data map[string]interface{}, signAppinResponse e
 
 	return owners
 }
-
 
 // GetOwnerDetailsGroupIdList constructs a list of owner details with group IDs from the provided data map.
 func GetOwnerDetailsGroupIdList(data map[string]interface{}, groupId int, signAppinResponse entities.SignAppinResponse) []entities.OwnerDetailsGroupId {
@@ -192,6 +207,7 @@ func GetUrlsDetailsList(d map[string]interface{}) []entities.UrlDetails {
 
 	return urls
 }
+
 // GetStringField retrieves a string field from a map, returning a default value if the key does not exist.
 func GetStringField(data map[string]interface{}, key string, defaultValue string) string {
 	val, exists := data[key]
@@ -211,10 +227,10 @@ func GetIntField(data map[string]interface{}, key string, defaultValue int) int 
 		return defaultValue
 	}
 	switch v := val.(type) {
-		case float64:
-			return int(v)
-		case int:
-			return v
+	case float64:
+		return int(v)
+	case int:
+		return v
 	}
 	return defaultValue
 }

--- a/api/utils/httpclient.go
+++ b/api/utils/httpclient.go
@@ -127,8 +127,16 @@ func GetPFXContent(clientCertificatePath string, clientCertificateName string, c
 //func (client *HttpClientObj) CallSecretSafeAPI(url string, httpMethod string, body bytes.Buffer, method string, accessToken string, apiKey string, contentType string) (io.ReadCloser, int, error, error) {
 
 func (client *HttpClientObj) CallSecretSafeAPI(callSecretSafeAPIObj entities.CallSecretSafeAPIObj) (io.ReadCloser, int, error, error) {
+	return client.CallSecretSafeAPIWithContext(context.Background(), callSecretSafeAPIObj)
+}
 
-	response, scode, technicalError, businessError := client.HttpRequest(callSecretSafeAPIObj.Url,
+// CallSecretSafeAPIWithContext prepares http call.
+func (client *HttpClientObj) CallSecretSafeAPIWithContext(ctx context.Context, callSecretSafeAPIObj entities.CallSecretSafeAPIObj) (io.ReadCloser, int, error, error) {
+	if callSecretSafeAPIObj.Ctx != nil {
+		ctx = callSecretSafeAPIObj.Ctx
+	}
+
+	response, scode, technicalError, businessError := client.HttpRequestWithContext(ctx, callSecretSafeAPIObj.Url,
 		callSecretSafeAPIObj.HttpMethod,
 		callSecretSafeAPIObj.Body,
 		callSecretSafeAPIObj.AccessToken,
@@ -182,14 +190,6 @@ func (client *HttpClientObj) SetApiVersion(url string, apiVersion string) string
 	return url
 }
 
-// resolveContext returns ctx if non-nil, otherwise context.Background().
-func resolveContext(ctx context.Context) context.Context {
-	if ctx == nil {
-		return context.Background()
-	}
-	return ctx
-}
-
 // handleDoError builds the appropriate return values when http.Client.Do returns an error.
 func (client *HttpClientObj) handleDoError(resp *http.Response, err error) (io.ReadCloser, int, error, error) {
 	client.log.Debug(fmt.Sprintf("%v %v", "Error Making request: ", err.Error()))
@@ -222,10 +222,15 @@ func (client *HttpClientObj) handleResponseStatus(resp *http.Response, method st
 
 // HttpRequest makes http request to the server.
 func (client *HttpClientObj) HttpRequest(url string, method string, body bytes.Buffer, accessToken string, apiKey string, contentType string, apiVersion string) (io.ReadCloser, int, error, error) {
+	return client.HttpRequestWithContext(context.Background(), url, method, body, accessToken, apiKey, contentType, apiVersion)
+}
+
+// HttpRequestWithContext makes http request to the server with context.
+func (client *HttpClientObj) HttpRequestWithContext(ctx context.Context, url string, method string, body bytes.Buffer, accessToken string, apiKey string, contentType string, apiVersion string) (io.ReadCloser, int, error, error) {
 	url = client.SetApiVersion(url, apiVersion)
 	client.log.Debug(fmt.Sprintf("Entire URL: %s", url))
 
-	req, err := http.NewRequestWithContext(resolveContext(client.Context), method, url, &body)
+	req, err := http.NewRequestWithContext(ctx, method, url, &body)
 	if err != nil {
 		return nil, 0, err, nil
 	}
@@ -244,6 +249,11 @@ func (client *HttpClientObj) HttpRequest(url string, method string, body bytes.B
 
 // CreateMultipartRequest creates and sends multipart request.
 func (client *HttpClientObj) CreateMultiPartRequest(url, fileName string, metadata []byte, fileContent string, apiVersion string) (io.ReadCloser, error) {
+	return client.CreateMultiPartRequestWithContext(context.Background(), url, fileName, metadata, fileContent, apiVersion)
+}
+
+// CreateMultiPartRequestWithContext creates and sends multipart request.
+func (client *HttpClientObj) CreateMultiPartRequestWithContext(ctx context.Context, url, fileName string, metadata []byte, fileContent string, apiVersion string) (io.ReadCloser, error) {
 
 	var requestBody bytes.Buffer
 
@@ -272,6 +282,7 @@ func (client *HttpClientObj) CreateMultiPartRequest(url, fileName string, metada
 	}
 
 	callSecretSafeAPIObj := &entities.CallSecretSafeAPIObj{
+		Ctx:         ctx,
 		ApiVersion:  apiVersion,
 		Url:         url,
 		HttpMethod:  "POST",
@@ -282,7 +293,7 @@ func (client *HttpClientObj) CreateMultiPartRequest(url, fileName string, metada
 		ContentType: multipartWriter.FormDataContentType(),
 	}
 
-	body, _, technicalError, businessError := client.CallSecretSafeAPI(*callSecretSafeAPIObj)
+	body, _, technicalError, businessError := client.CallSecretSafeAPIWithContext(ctx, *callSecretSafeAPIObj)
 
 	if technicalError != nil {
 		return body, technicalError
@@ -297,13 +308,18 @@ func (client *HttpClientObj) CreateMultiPartRequest(url, fileName string, metada
 
 // MakeRequest Make http request to API.
 func (client *HttpClientObj) MakeRequest(callSecretSafeAPIObj *entities.CallSecretSafeAPIObj, exponentialBackOff *backoff.ExponentialBackOff) ([]byte, error) {
+	return client.MakeRequestWithContext(context.Background(), callSecretSafeAPIObj, exponentialBackOff)
+}
+
+// MakeRequestWithContext makes http request to API with context.
+func (client *HttpClientObj) MakeRequestWithContext(ctx context.Context, callSecretSafeAPIObj *entities.CallSecretSafeAPIObj, exponentialBackOff *backoff.ExponentialBackOff) ([]byte, error) {
 
 	var body io.ReadCloser
 	var technicalError error
 	var businessError error
 
 	technicalError = backoff.Retry(func() error {
-		body, _, technicalError, businessError = client.CallSecretSafeAPI(*callSecretSafeAPIObj)
+		body, _, technicalError, businessError = client.CallSecretSafeAPIWithContext(ctx, *callSecretSafeAPIObj)
 		return technicalError
 	}, exponentialBackOff)
 
@@ -327,8 +343,14 @@ func (client *HttpClientObj) MakeRequest(callSecretSafeAPIObj *entities.CallSecr
 
 // GetGeneralList get list for any module.
 func (client *HttpClientObj) GetGeneralList(url string, apiVersion string, method string, exponentialBackOff *backoff.ExponentialBackOff) ([]byte, error) {
+	return client.GetGeneralListWithContext(context.Background(), url, apiVersion, method, exponentialBackOff)
+}
+
+// GetGeneralListWithContext gets list for any module with context.
+func (client *HttpClientObj) GetGeneralListWithContext(ctx context.Context, url string, apiVersion string, method string, exponentialBackOff *backoff.ExponentialBackOff) ([]byte, error) {
 
 	callSecretSafeAPIObj := &entities.CallSecretSafeAPIObj{
+		Ctx:         ctx,
 		Url:         url,
 		HttpMethod:  "GET",
 		Body:        bytes.Buffer{},
@@ -339,7 +361,7 @@ func (client *HttpClientObj) GetGeneralList(url string, apiVersion string, metho
 		ApiVersion:  apiVersion,
 	}
 
-	response, err := client.MakeRequest(callSecretSafeAPIObj, exponentialBackOff)
+	response, err := client.MakeRequestWithContext(ctx, callSecretSafeAPIObj, exponentialBackOff)
 
 	if err != nil {
 		return nil, err

--- a/api/workgroups/workgroups.go
+++ b/api/workgroups/workgroups.go
@@ -4,6 +4,7 @@ package workgroups
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -34,6 +35,11 @@ func NewWorkGroupObj(authentication authentication.AuthenticationObj, logger log
 
 // CreateWorkGroupFlow is responsible for creating workgroups in Password Safe.
 func (workGroupObj *WorkGroupObj) CreateWorkGroupFlow(workGroupDetails entities.WorkGroupDetails) (entities.WorkGroupResponse, error) {
+	return workGroupObj.CreateWorkGroupFlowWithContext(context.Background(), workGroupDetails)
+}
+
+// CreateWorkGroupFlowWithContext is responsible for creating workgroups in Password Safe.
+func (workGroupObj *WorkGroupObj) CreateWorkGroupFlowWithContext(ctx context.Context, workGroupDetails entities.WorkGroupDetails) (entities.WorkGroupResponse, error) {
 
 	var workGroupResponse entities.WorkGroupResponse
 
@@ -43,7 +49,7 @@ func (workGroupObj *WorkGroupObj) CreateWorkGroupFlow(workGroupDetails entities.
 		return workGroupResponse, err
 	}
 
-	workGroupResponse, err = workGroupObj.createWorkGroup(workGroupDetails)
+	workGroupResponse, err = workGroupObj.createWorkGroup(ctx, workGroupDetails)
 
 	if err != nil {
 		return workGroupResponse, err
@@ -53,7 +59,7 @@ func (workGroupObj *WorkGroupObj) CreateWorkGroupFlow(workGroupDetails entities.
 }
 
 // createWorkGroup calls Password Safe API enpoint to create workgroups.
-func (workGroupObj *WorkGroupObj) createWorkGroup(workGroup entities.WorkGroupDetails) (entities.WorkGroupResponse, error) {
+func (workGroupObj *WorkGroupObj) createWorkGroup(ctx context.Context, workGroup entities.WorkGroupDetails) (entities.WorkGroupResponse, error) {
 
 	path := "Workgroups"
 	method := constants.CreateWorkGroup
@@ -78,6 +84,7 @@ func (workGroupObj *WorkGroupObj) createWorkGroup(workGroup entities.WorkGroupDe
 	var businessError error
 
 	callSecretSafeAPIObj := &entities.CallSecretSafeAPIObj{
+		Ctx:         ctx,
 		Url:         createWorkGroupUrl,
 		HttpMethod:  "POST",
 		Body:        *b,
@@ -89,7 +96,7 @@ func (workGroupObj *WorkGroupObj) createWorkGroup(workGroup entities.WorkGroupDe
 	}
 
 	technicalError = backoff.Retry(func() error {
-		body, _, technicalError, businessError = workGroupObj.authenticationObj.HttpClient.CallSecretSafeAPI(*callSecretSafeAPIObj)
+		body, _, technicalError, businessError = workGroupObj.authenticationObj.HttpClient.CallSecretSafeAPIWithContext(ctx, *callSecretSafeAPIObj)
 		return technicalError
 	}, workGroupObj.authenticationObj.ExponentialBackOff)
 
@@ -121,12 +128,23 @@ func (workGroupObj *WorkGroupObj) createWorkGroup(workGroup entities.WorkGroupDe
 
 // GetWorkgroupListFlow get workgroup list.
 func (workGroupObj *WorkGroupObj) GetWorkgroupListFlow() ([]entities.WorkGroupResponse, error) {
-	return workGroupObj.GetWorkgroupList("Workgroups", constants.GetWorkGroupsList)
+	return workGroupObj.GetWorkgroupListFlowWithContext(context.Background())
+}
+
+// GetWorkgroupListFlowWithContext gets workgroup list.
+func (workGroupObj *WorkGroupObj) GetWorkgroupListFlowWithContext(ctx context.Context) ([]entities.WorkGroupResponse, error) {
+	return workGroupObj.GetWorkgroupListWithContext(ctx, "Workgroups", constants.GetWorkGroupsList)
 }
 
 // GetWorkgroupList call Workgroups enpoint
 // and returns workgroups list
 func (workGroupObj *WorkGroupObj) GetWorkgroupList(endpointPath string, method string) ([]entities.WorkGroupResponse, error) {
+	return workGroupObj.GetWorkgroupListWithContext(context.Background(), endpointPath, method)
+}
+
+// GetWorkgroupListWithContext calls Workgroups endpoint
+// and returns workgroups list
+func (workGroupObj *WorkGroupObj) GetWorkgroupListWithContext(ctx context.Context, endpointPath string, method string) ([]entities.WorkGroupResponse, error) {
 	messageLog := fmt.Sprintf("%v %v", "GET", endpointPath)
 	workGroupObj.log.Debug(messageLog)
 
@@ -134,7 +152,7 @@ func (workGroupObj *WorkGroupObj) GetWorkgroupList(endpointPath string, method s
 
 	var workgroupList []entities.WorkGroupResponse
 
-	response, err := workGroupObj.authenticationObj.HttpClient.GetGeneralList(url, workGroupObj.authenticationObj.ApiVersion, method, workGroupObj.authenticationObj.ExponentialBackOff)
+	response, err := workGroupObj.authenticationObj.HttpClient.GetGeneralListWithContext(ctx, url, workGroupObj.authenticationObj.ApiVersion, method, workGroupObj.authenticationObj.ExponentialBackOff)
 
 	if err != nil {
 		return workgroupList, err


### PR DESCRIPTION
### **Summary**
This PR adds context support across HTTP-facing Password Safe API methods while preserving backward compatibility for existing callers.

### **Current behavior**
Public API methods that trigger HTTP/network I/O did not consistently accept caller-provided context. This limited support for cancellation, deadlines, and request-scoped tracing across multi-step operations.

### **New behavior**

- Added WithContext variants for exported HTTP-facing methods, using context.Context as the first argument.
- Preserved existing exported method signatures.
- Existing methods now delegate to their WithContext counterpart using context.Background().
- Propagated context through internal HTTP helper layers to the final HTTP request execution path.
- Updated request execution paths to use context-aware HTTP request creation and execution.
- Added context support for shared delete/list/retry helper paths used by multiple modules.


### **Backward compatibility**
- No breaking API changes.
- Existing callers continue to work without code changes.
- New callers can opt into context-aware behavior incrementally.

### **Scope and boundaries**
Applied only to HTTP-facing APIs and required internal context plumbing.
No test additions or test refactors were included in this change.


### **Files changed**
- [entities.go](vscode-file://vscode-app/c:/Users/abdillahi.nur/AppData/Local/Programs/Microsoft%20VS%20Code/8761a5560c/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
- [httpclient.go](vscode-file://vscode-app/c:/Users/abdillahi.nur/AppData/Local/Programs/Microsoft%20VS%20Code/8761a5560c/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
- [common.go](vscode-file://vscode-app/c:/Users/abdillahi.nur/AppData/Local/Programs/Microsoft%20VS%20Code/8761a5560c/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
- [authentication.go](vscode-file://vscode-app/c:/Users/abdillahi.nur/AppData/Local/Programs/Microsoft%20VS%20Code/8761a5560c/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
- [assets.go](vscode-file://vscode-app/c:/Users/abdillahi.nur/AppData/Local/Programs/Microsoft%20VS%20Code/8761a5560c/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
- [databases.go](vscode-file://vscode-app/c:/Users/abdillahi.nur/AppData/Local/Programs/Microsoft%20VS%20Code/8761a5560c/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
- [functional_accounts.go](vscode-file://vscode-app/c:/Users/abdillahi.nur/AppData/Local/Programs/Microsoft%20VS%20Code/8761a5560c/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
- [managed_systems.go](vscode-file://vscode-app/c:/Users/abdillahi.nur/AppData/Local/Programs/Microsoft%20VS%20Code/8761a5560c/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
- [managed_account.go](vscode-file://vscode-app/c:/Users/abdillahi.nur/AppData/Local/Programs/Microsoft%20VS%20Code/8761a5560c/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
- [platforms.go](vscode-file://vscode-app/c:/Users/abdillahi.nur/AppData/Local/Programs/Microsoft%20VS%20Code/8761a5560c/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
- [workgroups.go](vscode-file://vscode-app/c:/Users/abdillahi.nur/AppData/Local/Programs/Microsoft%20VS%20Code/8761a5560c/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
- [secrets.go](vscode-file://vscode-app/c:/Users/abdillahi.nur/AppData/Local/Programs/Microsoft%20VS%20Code/8761a5560c/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
- [session.go](vscode-file://vscode-app/c:/Users/abdillahi.nur/AppData/Local/Programs/Microsoft%20VS%20Code/8761a5560c/resources/app/out/vs/code/electron-browser/workbench/workbench.html)

### **Validation**
Repository builds successfully with go build ./...