### PR TITLE
fix: bump Go toolchain to 1.26.5 to resolve crypto/tls govulncheck alert

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/BeyondTrust/go-client-library-passwordsafe
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/AdamKorcz/go-118-fuzz-build v0.0.0-20250520111509-a70c2aa677fa


### PR DESCRIPTION
## Purpose of the PR

- Bump Go toolchain to 1.26.5 to resolve crypto/tls govulncheck alert (GO-2026-5856)

## Linked JIRA issue(s)

- [BIPS-40695](https://beyondtrust.atlassian.net/browse/BIPS-40695)

## Summary of changes

The `golint` CI workflow's `govulncheck` step was failing: https://github.com/BeyondTrust/go-client-library-passwordsafe/actions/runs/29595341270

`govulncheck` flagged **GO-2026-5856** (Encrypted Client Hello privacy leak in `crypto/tls`), a Go standard library vulnerability present in go1.26.1–go1.26.4, fixed in **go1.26.5**. Call sites flagged were `authentication.go:285` (`SignOut`), and `httpclient.go:267`/`293` (`HttpRequest`, `CreateMultiPartRequest`) — all via transitive stdlib calls into `crypto/tls`, not vulnerable code we wrote.

CI uses `actions/setup-go@v6.3.0` with `go-version-file: go.mod`, so it installs whichever Go version is pinned there. This PR bumps the `go` directive from `1.26.4` to `1.26.5` so CI installs the patched toolchain.

Verified locally with go1.26.5:
- `go build ./...` — succeeds
- `govulncheck ./...` — 0 vulnerabilities found (previously reported 1)
- `go test ./...` — same two pre-existing failures in `api/utils` (`TestValidateInputs`, `TestValidateCertificateInfo`) reproduce identically on `main` with go1.26.4, confirming they're unrelated to this change

## Checklist

### Release

- [ ]  Priority release required due to Hot fix / Escalation / Critical bug
- [x]  Priority release not required (can be released later with other stories or bugs fixes)

### Testing

- [x] dev — verified `go build`, `go test`, and `govulncheck` locally with go1.26.5
- [ ] automation (required for feature branch merges and significant changes)
- [ ] manual (required for feature branch merges and significant changes)

### Automation

- [x] no changes are required


[BIPS-40695]: https://beyondtrust.atlassian.net/browse/BIPS-40695?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ